### PR TITLE
COCO superset for proper SemVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 ---
 [![PyPI](https://img.shields.io/pypi/v/geococo)](https://pypi.org/project/geococo/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/geococo)
+[![Build passing](https://github.com/jaspersiebring/GeoCOCO/actions/workflows/main.yml/badge.svg)](https://github.com/jaspersiebring/GeoCOCO/actions/workflows/main.yml)
 
-
+https://github.com/jaspersiebring/GeoCOCO/blob/main/.github/workflows/main.yml
 Easily transform your GIS annotations into [Microsoft's Common Objects In Context (COCO)](https://cocodataset.org/#format-data) datasets with GeoCOCO. This tool allows users to leverage the advanced digitizing solutions of modern GIS software for the annotations of image objects in geographic imagery.
  
 Built with `Pydantic` and `pycocotools`, it features a complete implementation of the COCO standard for object detection with out-of-the-box support for JSON-encoding and RLE compression. The resulting datasets are versioned, easily extendable with new annotations and fully compatible with other data applications that accept the COCO format.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/geococo)
 [![Build passing](https://github.com/jaspersiebring/GeoCOCO/actions/workflows/main.yml/badge.svg)](https://github.com/jaspersiebring/GeoCOCO/actions/workflows/main.yml)
 
-https://github.com/jaspersiebring/GeoCOCO/blob/main/.github/workflows/main.yml
 Easily transform your GIS annotations into [Microsoft's Common Objects In Context (COCO)](https://cocodataset.org/#format-data) datasets with GeoCOCO. This tool allows users to leverage the advanced digitizing solutions of modern GIS software for the annotations of image objects in geographic imagery.
  
 Built with `Pydantic` and `pycocotools`, it features a complete implementation of the COCO standard for object detection with out-of-the-box support for JSON-encoding and RLE compression. The resulting datasets are versioned, easily extendable with new annotations and fully compatible with other data applications that accept the COCO format.
@@ -96,14 +95,14 @@ from geococo import create_dataset, load_dataset, save_dataset, labels_to_datase
 data_path = pathlib.Path("path/to/your/coco/output/images")
 json_path = pathlib.Path("path/to/your/coco/json/file")
 
-# Width and height of the output images
+# Dimensions of the moving window and output images
 width, height = 512, 512
 
 # Creating dataset instance from scratch
-version = "0.1.0"
 description = "My First Dataset"
 contributor = "User'
 date_created = datetime.now()
+
 dataset = create_dataset(
   version = version, 
   description = description, 
@@ -111,21 +110,21 @@ dataset = create_dataset(
   date_created = date_created
 )
 
-# Loading existing dataset instance
+# You can also load existing COCO datasets
 # dataset = load_dataset(json_path=json_path)
 
 # Loading GIS data with rasterio and geopandas
 labels = gpd.read_file(labels_path)
-with rasterio.open(image_path) as src:
+raster_source = rasterio.open(image_path)
 
-    # Appending Annotation instances to dataset and clipping the image part that contains them
-    dataset = labels_to_dataset(
-        dataset = dataset, 
-        images_dir = output_dir,
-        src = src,
-        labels = labels,
-        window_bounds = [(width, height)]
-        )
+# Moving across raster_source and appending all intersecting annotations
+dataset = labels_to_dataset(
+    dataset = dataset, 
+    images_dir = output_dir,
+    src = raster_source,
+    labels = labels,
+    window_bounds = [(width, height)]
+    )
 
 # Encode CocoDataset instance as JSON and save to json_path
 save_dataset(dataset=dataset, json_path=json_path)

--- a/geococo/__init__.py
+++ b/geococo/__init__.py
@@ -5,7 +5,18 @@ from .coco_manager import create_dataset, load_dataset, save_dataset
 from .cli import build_coco
 
 # We make this specific warning 'catchable' to ensure that all rasterio clips are valid
-warnings.filterwarnings('error', 'shapes are outside bounds of raster. Are they in different coordinate reference systems?', category=UserWarning)
+warnings.filterwarnings(
+    "error",
+    "shapes are outside bounds of raster. Are they in different coordinate reference "
+    "systems?",
+    category=UserWarning,
+)
 
 # TODO: not matching yet (needed for raster_factory)
-warnings.filterwarnings('error', 'The given matrix is equal to Affine.identity or its flipped counterpart. GDAL may ignore this matrix and save no geotransform without raising an error. This behavior is somewhat driver-specific.', category=NotGeoreferencedWarning)
+warnings.filterwarnings(
+    "error",
+    "The given matrix is equal to Affine.identity or its flipped counterpart. GDAL may"
+     " ignore this matrix and save no geotransform without raising an error. This "
+     "behavior is somewhat driver-specific.",
+    category=NotGeoreferencedWarning,
+)

--- a/geococo/cli.py
+++ b/geococo/cli.py
@@ -6,27 +6,42 @@ import rasterio
 from geococo.coco_processing import labels_to_dataset
 from geococo.coco_manager import save_dataset, load_dataset, create_dataset
 
-def build_coco(image_path: pathlib.Path, labels_path: pathlib.Path, json_path: pathlib.Path, output_dir: pathlib.Path, width: int, height: int, category_attribute: str = "category_id") -> None:
-    """
-    Transform your GIS annotations into a COCO dataset.
 
-    This method generates a COCO dataset by moving across the given image (image_path) with a
-    moving window (image_size), constantly checking for intersecting annotations (labels_path) 
-    that represent image objects in said image (e.g. buildings in satellite imagery; denoted 
-    by category_attribute). Each valid intersection will add n Annotations entries to the dataset 
-    (json_path) and save a subset of the input image that contained these entries (output_dir).
+def build_coco(
+    image_path: pathlib.Path,
+    labels_path: pathlib.Path,
+    json_path: pathlib.Path,
+    output_dir: pathlib.Path,
+    width: int,
+    height: int,
+    category_attribute: str = "category_id",
+) -> None:
+    """Transform your GIS annotations into a COCO dataset.
 
-    The output data size depends on your input labels, as the moving window adjusts its step size 
-    to accommodate the average annotation size, optimizing dataset representation and minimizing 
-    tool configuration.
-    
-    :param image_path: Path to the geospatial image containing image objects (e.g. buildings in satellite imagery)
-    :param labels_path: Path to the annotations representing these image objects (='category_id')
-    :param json_path: Path to the json file that will store the COCO dataset (will be appended to if already exists)
+    This method generates a COCO dataset by moving across the given
+    image (image_path) with a moving window (image_size), constantly
+    checking for intersecting annotations (labels_path) that represent
+    image objects in said image (e.g. buildings in satellite imagery;
+    denoted by category_attribute). Each valid intersection will add n
+    Annotations entries to the dataset (json_path) and save a subset of
+    the input image that contained these entries (output_dir).
+
+    The output data size depends on your input labels, as the moving
+    window adjusts its step size to accommodate the average annotation
+    size, optimizing dataset representation and minimizing tool
+    configuration.
+
+    :param image_path: Path to the geospatial image containing image
+        objects (e.g. buildings in satellite imagery)
+    :param labels_path: Path to the annotations representing these image
+        objects (='category_id')
+    :param json_path: Path to the json file that will store the COCO
+        dataset (will be appended to if already exists)
     :param output_dir: Path to the output directory for image subsets
-    :param width: Width of the output images 
+    :param width: Width of the output images
     :param height: Height of the output images
-    :param category_attribute: Column that contains category_id values per annotation feature
+    :param category_attribute: Column that contains category_id values
+        per annotation feature
     """
 
     if isinstance(json_path, pathlib.Path) and json_path.exists():
@@ -46,28 +61,32 @@ def build_coco(image_path: pathlib.Path, labels_path: pathlib.Path, json_path: p
             version=version,
             description=description,
             contributor=contributor,
-            date_created=date_created
-            )
-    
+            date_created=date_created,
+        )
+
     # Loading and validating GIS data
     labels = gpd.read_file(labels_path)
     if not labels.is_valid.all():
         raise ValueError("Invalid geometry found, exiting..")
     elif category_attribute not in labels.columns:
-        raise ValueError(f"User-specified category attribute (={category_attribute}) not found in input labels, exiting..")
-    
+        raise ValueError(
+            f"User-specified category attribute (={category_attribute}) not found in "
+            "input labels, exiting.."
+        )
+
     with rasterio.open(image_path) as src:
-        # Appending Annotation instances to dataset and clipping the image part that contains them
+        # Appending Annotation instances and clipping the image part that contains them
         dataset = labels_to_dataset(
-            dataset = dataset, 
-            images_dir = output_dir,
-            src = src,
-            labels = labels,
-            window_bounds = [(width, height)]
-            )
+            dataset=dataset,
+            images_dir=output_dir,
+            src=src,
+            labels=labels,
+            window_bounds=[(width, height)],
+        )
 
     # Encode CocoDataset instance as JSON and save to json_path
     save_dataset(dataset=dataset, json_path=json_path)
+
 
 if __name__ == "__main__":
     typer.run(build_coco)

--- a/geococo/coco_manager.py
+++ b/geococo/coco_manager.py
@@ -1,3 +1,4 @@
+from semver import Version
 from datetime import datetime
 import pathlib
 from geococo.coco_models import CocoDataset, Info
@@ -20,17 +21,18 @@ def load_dataset(json_path: pathlib.Path) -> CocoDataset:
 
 
 def create_dataset(
-    version: str,
     description: str,
     contributor: str,
+    version: str = str(Version(major=0)),
     date_created: datetime = datetime.now(),
 ) -> CocoDataset:
-    """Instances and returns a new CocoDataset model with given kwargs.
+    """
+    Instances and returns a new CocoDataset model with given kwargs.
 
-    :param version: SemVer version of your COCO dataset
     :param description: Description of your COCO dataset
     :param contributor: Main contributors of your COCO dataset, its
         images and its annotations
+    :param version: Initial SemVer version (defaults to 0.0.0)
     :param date_created: Date when dataset was initially created,
         defaults to datetime.now()
     :return: An instance of CocoDataset without Image- and Annotation

--- a/geococo/coco_manager.py
+++ b/geococo/coco_manager.py
@@ -2,29 +2,39 @@ from datetime import datetime
 import pathlib
 from geococo.coco_models import CocoDataset, Info
 
+
 def load_dataset(json_path: pathlib.Path) -> CocoDataset:
-    """
-    Dumps the contents of json_path as a string, interprets it as a CocoDataset model and returns it.
+    """Dumps the contents of json_path as a string, interprets it as a
+    CocoDataset model and returns it.
 
-    :param json_path: path to the JSON file containing the json-encoded COCO dataset 
-    :return: An instance of CocoDataset with loaded Image- and Annotation objects from json_path
+    :param json_path: path to the JSON file containing the json-encoded
+        COCO dataset
+    :return: An instance of CocoDataset with loaded Image- and
+        Annotation objects from json_path
     """
 
-    with open(json_path, mode='r', encoding="utf-8") as json_fp:
+    with open(json_path, mode="r", encoding="utf-8") as json_fp:
         json_data = json_fp.read()
     dataset = CocoDataset.model_validate_json(json_data)
     return dataset
 
-    
-def create_dataset(version: str, description: str, contributor: str, date_created: datetime = datetime.now()) -> CocoDataset:
-    """
-    Instances and returns a new CocoDataset model with given kwargs
+
+def create_dataset(
+    version: str,
+    description: str,
+    contributor: str,
+    date_created: datetime = datetime.now(),
+) -> CocoDataset:
+    """Instances and returns a new CocoDataset model with given kwargs.
 
     :param version: SemVer version of your COCO dataset
     :param description: Description of your COCO dataset
-    :param contributor: Main contributors of your COCO dataset, its images and its annotations
-    :param date_created: Date when dataset was initially created, defaults to datetime.now()
-    :return: An instance of CocoDataset without Image- and Annotation objects
+    :param contributor: Main contributors of your COCO dataset, its
+        images and its annotations
+    :param date_created: Date when dataset was initially created,
+        defaults to datetime.now()
+    :return: An instance of CocoDataset without Image- and Annotation
+        objects
     """
 
     info = Info(
@@ -32,19 +42,20 @@ def create_dataset(version: str, description: str, contributor: str, date_create
         description=description,
         contributor=contributor,
         date_created=date_created,
-        year= date_created.year
+        year=date_created.year,
     )
-    dataset = CocoDataset(info = info)
+    dataset = CocoDataset(info=info)
     return dataset
 
+
 def save_dataset(dataset: CocoDataset, json_path: pathlib.Path) -> None:
-    """
-    JSON-encodes an instance of CocoDataset and saves it to json_path
+    """JSON-encodes an instance of CocoDataset and saves it to json_path.
 
     :param dataset: An instance of CocoDataset
-    :param json_path: where to save the JSON-encoded CocoDataset instance to
+    :param json_path: where to save the JSON-encoded CocoDataset
+        instance to
     """
 
     json_data = dataset.model_dump_json()
-    with open(json_path, mode='w', encoding="utf-8") as dst:
+    with open(json_path, mode="w", encoding="utf-8") as dst:
         dst.write(json_data)

--- a/geococo/coco_models.py
+++ b/geococo/coco_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import pathlib
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Set
 from typing_extensions import TypedDict
 from pydantic import BaseModel, ConfigDict, InstanceOf, model_validator
 
@@ -11,13 +11,18 @@ class CocoDataset(BaseModel):
     images: List[InstanceOf[Image]] = []
     annotations: List[InstanceOf[Annotation]] = []
     categories: List[InstanceOf[Category]] = []
+    sources: List[InstanceOf[Source]] = []
     _next_image_id: int = 1
     _next_annotation_id: int = 1
-
+    _next_source_id: int = 1
+    _unique_output_dirs: Set[pathlib.Path] = set()
+    _unique_source_images : Set[pathlib.Path] = set()
+    
     @model_validator(mode="after")
     def _set_ids(self) -> CocoDataset:
         self._next_image_id = len(self.images) + 1
         self._next_annotation_id = len(self.annotations) + 1
+        self._next_source_id = len(self.sources) + 1
         return self
 
     def add_annotation(self, annotation: Annotation) -> None:
@@ -28,6 +33,10 @@ class CocoDataset(BaseModel):
         self.images.append(image)
         self._next_image_id += 1
 
+    def add_source(self, source: Source) -> None:
+        self.sources.append(source)
+        self._next_source_id += 1
+    
     @property
     def next_image_id(self) -> int:
         return self._next_image_id
@@ -35,6 +44,10 @@ class CocoDataset(BaseModel):
     @property
     def next_annotation_id(self) -> int:
         return self._next_annotation_id
+    
+    @property
+    def next_source_id(self) -> int:
+        return self._next_source_id
 
 
 class Info(BaseModel):
@@ -51,6 +64,7 @@ class Image(BaseModel):
     width: int
     height: int
     file_name: pathlib.Path
+    source_id: int
 
 
 class Annotation(BaseModel):
@@ -74,3 +88,8 @@ class Category(BaseModel):
 class RleDict(TypedDict):
     size: List[int]
     counts: bytes
+
+
+class Source(BaseModel):
+    source_id: int
+    file_name: pathlib.Path

--- a/geococo/coco_processing.py
+++ b/geococo/coco_processing.py
@@ -60,8 +60,8 @@ def labels_to_dataset(
     coco_profile.update({"dtype": np.uint8, "nodata": nodata_value, "driver": "JPEG"})
     schema = estimate_schema(gdf=labels, src=src, window_bounds=window_bounds)
     n_windows = generate_window_offsets(window=parent_window, schema=schema).shape[0]
-    source=Source(file_name=pathlib.Path(src.name), source_id=dataset.next_source_id)
-    
+    source = Source(file_name=pathlib.Path(src.name), source_id=dataset.next_source_id)
+
     for child_window in tqdm(
         window_factory(parent_window=parent_window, schema=schema), total=n_windows
     ):
@@ -92,8 +92,8 @@ def labels_to_dataset(
                 alpha=0,
                 beta=255,
                 norm_type=cv2.NORM_MINMAX,
-                dtype=cv2.CV_8U
-                )  # type: ignore
+                dtype=cv2.CV_8U,  # type: ignore
+            )
 
         # updating rasterio profile with window-specific values
         coco_profile.update(
@@ -106,8 +106,7 @@ def labels_to_dataset(
 
         # saving window_image to disk (if it doesn't exist already)
         window_image_path = (
-            images_dir
-            / f"{child_window.col_off}_{child_window.row_off}_"
+            images_dir / f"{child_window.col_off}_{child_window.row_off}_"
             f"{child_window.width}_{child_window.height}.jpg"
         )
         if not window_image_path.exists():

--- a/geococo/coco_processing.py
+++ b/geococo/coco_processing.py
@@ -60,8 +60,10 @@ def labels_to_dataset(
     coco_profile.update({"dtype": np.uint8, "nodata": nodata_value, "driver": "JPEG"})
     schema = estimate_schema(gdf=labels, src=src, window_bounds=window_bounds)
     n_windows = generate_window_offsets(window=parent_window, schema=schema).shape[0]
-    source = Source(file_name=pathlib.Path(src.name), source_id=dataset.next_source_id)
 
+    # sets dataset.next_source_id
+    dataset.add_source(source_path=pathlib.Path(src.name))
+    
     for child_window in tqdm(
         window_factory(parent_window=parent_window, schema=schema), total=n_windows
     ):
@@ -148,6 +150,4 @@ def labels_to_dataset(
 
                 dataset.add_annotation(annotation=annotation_instance)
         dataset.add_image(image=image_instance)
-    dataset.add_source(source=source)
-
     return dataset

--- a/geococo/coco_processing.py
+++ b/geococo/coco_processing.py
@@ -10,82 +10,125 @@ from rasterio.mask import mask as riomask
 from shapely.geometry import MultiPolygon
 from tqdm import tqdm
 from geococo.coco_models import Annotation, CocoDataset, Image, Source
-from geococo.utils import estimate_schema, generate_window_offsets, window_factory, generate_window_polygon, reshape_image, window_intersect, mask_label
+from geococo.utils import (
+    estimate_schema,
+    generate_window_offsets,
+    window_factory,
+    generate_window_polygon,
+    reshape_image,
+    window_intersect,
+    mask_label,
+)
 
 
-def labels_to_dataset(dataset: CocoDataset, images_dir: pathlib.Path, src: DatasetReader, labels: gpd.GeoDataFrame, window_bounds:  List[Tuple[int, int]]) -> CocoDataset:
-    """
-    Move across a given geotiff, converting all intersecting labels to COCO annotations and 
-    appending them to a COCODataset model. This is done through rasterio.Window objects, the 
-    bounds of which you can set with window_bounds (also determines the size of the output 
-    images associated with the Annotation instances). The degree of overlap between these 
-    windows is determined by the dimensions of the given labels to maximize representation 
+def labels_to_dataset(
+    dataset: CocoDataset,
+    images_dir: pathlib.Path,
+    src: DatasetReader,
+    labels: gpd.GeoDataFrame,
+    window_bounds: List[Tuple[int, int]],
+) -> CocoDataset:
+    """Move across a given geotiff, converting all intersecting labels to COCO
+    annotations and appending them to a COCODataset model. This is done through
+    rasterio.Window objects, the bounds of which you can set with window_bounds
+    (also determines the size of the output images associated with the
+    Annotation instances). The degree of overlap between these windows is
+    determined by the dimensions of the given labels to maximize representation
     in the resulting dataset.
 
-    The "iscrowd" attribute (see https://cocodataset.org/#format-data) is determined by whether
-    the respective labels are Polygon or MultiPolygon instances. The "category_id" attribute, 
-    which represents class or category identifiers, is expected to be present in the given labels 
-    GeoDataFrame under the same name.
-    
-    :param dataset: CocoDataset model to append images and annotations to
+    The "iscrowd" attribute (see
+    https://cocodataset.org/#format-data)
+    is determined by whether    the respective labels are Polygon or
+    MultiPolygon instances. The "category_id" attribute,    which
+    represents class or category identifiers, is expected to be present
+    in the given labels    GeoDataFrame under the same name.
+
+    :param dataset: CocoDataset model to append images and annotations
+        to
     :param images_dir: output directory for all label images
-    :param src: open rasterio reader for input raster 
-    :param labels: GeoDataFrame containing labels and class_info ('category_id')
+    :param src: open rasterio reader for input raster
+    :param labels: GeoDataFrame containing labels and class_info
+        ('category_id')
     :param window_bounds: a list of window_bounds to attempt to use ()
     :return: The COCO dataset with appended Images and Annotations
     """
 
     # Setting nodata and estimating window configuration
     parent_window = window_intersect(input_raster=src, input_vector=labels)
-    nodata_value = src.nodata if src.nodata else 0    
+    nodata_value = src.nodata if src.nodata else 0
     coco_profile = src.profile.copy()
-    coco_profile.update({'dtype': np.uint8, 'nodata': nodata_value, "driver": "JPEG"})
-    schema = estimate_schema(gdf=labels, src=src, window_bounds = window_bounds)
-    n_windows = generate_window_offsets(window = parent_window, schema = schema).shape[0]
-
-    for child_window in tqdm(window_factory(parent_window=parent_window, schema=schema), total=n_windows):
-
+    coco_profile.update({"dtype": np.uint8, "nodata": nodata_value, "driver": "JPEG"})
+    schema = estimate_schema(gdf=labels, src=src, window_bounds=window_bounds)
+    n_windows = generate_window_offsets(window=parent_window, schema=schema).shape[0]
+    source=Source(file_name=pathlib.Path(src.name), source_id=dataset.next_source_id)
+    
+    for child_window in tqdm(
+        window_factory(parent_window=parent_window, schema=schema), total=n_windows
+    ):
         # changing window to Shapely.geometry, used to check for intersecting labels
-        window_geom = generate_window_polygon(datasource=src, window = child_window)
+        window_geom = generate_window_polygon(datasource=src, window=child_window)
         intersect_mask = labels.intersects(window_geom)
         if not intersect_mask.any():
             continue
-        
+
         # all_touched is needed because of np.ceil in WindowSource
         window_labels = labels[intersect_mask]
-        window_image, window_transform = riomask(dataset=src, shapes=[window_geom], all_touched=True, crop=True)
-        
-        # padding is needed because rasterio clips any mask to the extent of the given datasource        
+        window_image, window_transform = riomask(
+            dataset=src, shapes=[window_geom], all_touched=True, crop=True
+        )
+
+        # padding is needed because rasterio clips any mask to the extent of the source
         window_shape = (src.count, child_window.width, child_window.height)
         if window_image.shape != window_shape:
-            window_image = reshape_image(img_array=window_image, shape=window_shape, padding_value=nodata_value)
+            window_image = reshape_image(
+                img_array=window_image, shape=window_shape, padding_value=nodata_value
+            )
 
-        # normalizing values to uint8 range (i.e COCO dtype) 
+        # normalizing values to uint8 range (i.e COCO dtype)
         if window_image.dtype != np.uint8:
-            window_image = cv2.normalize(window_image, None, alpha=0, beta=255, norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_8U) # type: ignore
+            window_image = cv2.normalize(
+                window_image,
+                None,
+                alpha=0,
+                beta=255,
+                norm_type=cv2.NORM_MINMAX,
+                dtype=cv2.CV_8U
+                )  # type: ignore
 
         # updating rasterio profile with window-specific values
-        coco_profile.update({'width': window_image.shape[1], 'height': window_image.shape[2], 'transform': window_transform})
-        
+        coco_profile.update(
+            {
+                "width": window_image.shape[1],
+                "height": window_image.shape[2],
+                "transform": window_transform,
+            }
+        )
+
         # saving window_image to disk (if it doesn't exist already)
-        window_image_path = images_dir / f"{child_window.col_off}_{child_window.row_off}_{child_window.width}_{child_window.height}.jpg"
+        window_image_path = (
+            images_dir
+            / f"{child_window.col_off}_{child_window.row_off}_"
+            f"{child_window.width}_{child_window.height}.jpg"
+        )
         if not window_image_path.exists():
-            with rasterio.open(window_image_path, 'w', **coco_profile) as dst:
+            with rasterio.open(window_image_path, "w", **coco_profile) as dst:
                 dst.write(window_image)
-        
-        # Instancing and adding Image model to dataset (also bumps next_image_id) 
+
+        # Instancing and adding Image model to dataset (also bumps next_image_id)
         image_instance = Image(
             id=dataset.next_image_id,
             width=window_image.shape[1],
             height=window_image.shape[2],
-            file_name = window_image_path,
-            source_id=dataset.next_source_id
-            )
+            file_name=window_image_path,
+            source_id=dataset.next_source_id,
+        )
 
         # Iteratively add Annotation models to dataset (also bumps next_annotation_id)
         with rasterio.open(window_image_path) as windowed_src:
-            for _, window_label in window_labels.sort_values('category_id').iterrows():
-                label_mask = mask_label(input_raster=windowed_src, label=window_label.geometry)
+            for _, window_label in window_labels.sort_values("category_id").iterrows():
+                label_mask = mask_label(
+                    input_raster=windowed_src, label=window_label.geometry
+                )
                 if not label_mask.any():
                     continue
 
@@ -95,17 +138,17 @@ def labels_to_dataset(dataset: CocoDataset, images_dir: pathlib.Path, src: Datas
                 iscrowd = 1 if isinstance(window_label.geometry, MultiPolygon) else 0
 
                 annotation_instance = Annotation(
-                    id = dataset.next_annotation_id,
-                    image_id = dataset.next_image_id,
-                    category_id=window_label['category_id'],
-                    segmentation=rle, # type: ignore
+                    id=dataset.next_annotation_id,
+                    image_id=dataset.next_image_id,
+                    category_id=window_label["category_id"],
+                    segmentation=rle,  # type: ignore
                     area=area,
-                    bbox = bounding_box,
-                    iscrowd=iscrowd
-                    )
-                
+                    bbox=bounding_box,
+                    iscrowd=iscrowd,
+                )
+
                 dataset.add_annotation(annotation=annotation_instance)
         dataset.add_image(image=image_instance)
-    dataset.add_source(source=Source(file_name=pathlib.Path(src.name), source_id=dataset.next_source_id))
-    
+    dataset.add_source(source=source)
+
     return dataset

--- a/geococo/coco_processing.py
+++ b/geococo/coco_processing.py
@@ -62,7 +62,7 @@ def labels_to_dataset(dataset: CocoDataset, images_dir: pathlib.Path, src: Datas
 
         # normalizing values to uint8 range (i.e COCO dtype) 
         if window_image.dtype != np.uint8:
-            window_image = cv2.normalize(window_image, None, alpha=0, beta=255, norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_8U)
+            window_image = cv2.normalize(window_image, None, alpha=0, beta=255, norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_8U) # type: ignore
 
         # updating rasterio profile with window-specific values
         coco_profile.update({'width': window_image.shape[1], 'height': window_image.shape[2], 'transform': window_transform})
@@ -98,7 +98,7 @@ def labels_to_dataset(dataset: CocoDataset, images_dir: pathlib.Path, src: Datas
                     id = dataset.next_annotation_id,
                     image_id = dataset.next_image_id,
                     category_id=window_label['category_id'],
-                    segmentation=rle,
+                    segmentation=rle, # type: ignore
                     area=area,
                     bbox = bounding_box,
                     iscrowd=iscrowd

--- a/geococo/coco_processing.py
+++ b/geococo/coco_processing.py
@@ -9,7 +9,7 @@ from rasterio.io import DatasetReader
 from rasterio.mask import mask as riomask
 from shapely.geometry import MultiPolygon
 from tqdm import tqdm
-from geococo.coco_models import Annotation, CocoDataset, Image
+from geococo.coco_models import Annotation, CocoDataset, Image, Source
 from geococo.utils import estimate_schema, generate_window_offsets, window_factory, generate_window_polygon, reshape_image, window_intersect, mask_label
 
 
@@ -78,7 +78,8 @@ def labels_to_dataset(dataset: CocoDataset, images_dir: pathlib.Path, src: Datas
             id=dataset.next_image_id,
             width=window_image.shape[1],
             height=window_image.shape[2],
-            file_name = window_image_path
+            file_name = window_image_path,
+            source_id=dataset.next_source_id
             )
 
         # Iteratively add Annotation models to dataset (also bumps next_annotation_id)
@@ -105,5 +106,6 @@ def labels_to_dataset(dataset: CocoDataset, images_dir: pathlib.Path, src: Datas
                 
                 dataset.add_annotation(annotation=annotation_instance)
         dataset.add_image(image=image_instance)
-        
+    dataset.add_source(source=Source(file_name=pathlib.Path(src.name), source_id=dataset.next_source_id))
+    
     return dataset

--- a/geococo/utils.py
+++ b/geococo/utils.py
@@ -9,39 +9,52 @@ from rasterio.mask import mask as riomask
 from shapely.geometry import MultiPolygon, Polygon, box
 from geococo.window_schema import WindowSchema
 
-def mask_label(input_raster: DatasetReader, label: Union[Polygon, MultiPolygon]) -> np.ndarray:
 
-    """
-    Masks out an label from input_raster and flattens it to a 2D binary array. If it doesn't 
-    overlap, the resulting mask will only consist of False bools.
-    
-    :param input_raster: open rasterio DatasetReader for the input raster
-    :param label: Polygon object representing the area to be masked (i.e. label)
+def mask_label(
+    input_raster: DatasetReader, label: Union[Polygon, MultiPolygon]
+) -> np.ndarray:
+    """Masks out an label from input_raster and flattens it to a 2D binary
+    array. If it doesn't overlap, the resulting mask will only consist of False
+    bools.
+
+    :param input_raster: open rasterio DatasetReader for the input
+        raster
+    :param label: Polygon object representing the area to be masked
+        (i.e. label)
     :return: A 2D binary array representing the label
     """
 
     if input_raster.closed:
         raise ValueError("Attempted mask with a closed DatasetReader")
-    
-    label_mask, _ = riomask(dataset=input_raster, shapes = [label], all_touched=True, filled=False)
+
+    label_mask, _ = riomask(
+        dataset=input_raster, shapes=[label], all_touched=True, filled=False
+    )
     label_mask = np.all(label_mask.mask, axis=0)
     label_mask = np.invert(label_mask)
 
     return label_mask
 
-def window_intersect(input_raster: DatasetReader, input_vector: gpd.GeoDataFrame) -> Window:
-    """
-    Generates a Rasterio Window from the intersecting extents of the input data. 
-    It also verifies if the input data share the same CRS and if they physically overlap.
+
+def window_intersect(
+    input_raster: DatasetReader, input_vector: gpd.GeoDataFrame
+) -> Window:
+    """Generates a Rasterio Window from the intersecting extents of the input
+    data. It also verifies if the input data share the same CRS and if they
+    physically overlap.
 
     :param input_raster: rasterio dataset (i.e. input image)
     :param input_vector: geopandas geodataframe (i.e. input labels)
-    :return: rasterio window that represent the intersection between input data extents
-    """        
+    :return: rasterio window that represent the intersection between
+        input data extents
+    """
 
     if input_vector.crs != input_raster.crs:
-        raise ValueError(f"CRS of input raster ({input_raster.crs.to_epsg()}) and labels ({input_vector.crs.to_epsg()}) don't match, exiting..")
-    
+        raise ValueError(
+            f"CRS of input raster ({input_raster.crs.to_epsg()}) and "
+            "labels ({input_vector.crs.to_epsg()}) don't match, exiting.."
+        )
+
     raster_bounds = input_raster.bounds
     vector_bounds = input_vector.total_bounds
     raster_window = from_bounds(*raster_bounds, transform=input_raster.transform)
@@ -50,37 +63,49 @@ def window_intersect(input_raster: DatasetReader, input_vector: gpd.GeoDataFrame
     try:
         intersection_window = vector_window.intersection(raster_window)
     except WindowError as window_error:
-        raise ValueError("Extent of input raster and vector don't overlap") from window_error
-    
+        raise ValueError(
+            "Extent of input raster and vector don't overlap"
+        ) from window_error
+
     return intersection_window
 
-def reshape_image(img_array: np.ndarray, shape: Tuple[int, int, int], padding_value: int = 0) -> np.ndarray:
-    """
-    Reshapes 3D numpy array to match given 3D shape, done through slicing or padding. 
 
-    :param img_array: the numpy array to be reshaped 
+def reshape_image(
+    img_array: np.ndarray, shape: Tuple[int, int, int], padding_value: int = 0
+) -> np.ndarray:
+    """Reshapes 3D numpy array to match given 3D shape, done through slicing or
+    padding.
+
+    :param img_array: the numpy array to be reshaped
     :param shape: the desired shape (bands, rows, cols)
-    :param padding_value: what value to pad img_array with (if too small)
-    :return: numpy array in desired shape 
+    :param padding_value: what value to pad img_array with (if too
+        small)
+    :return: numpy array in desired shape
     """
 
     if len(img_array.shape) != len(shape):
-        raise ValueError(f"Number of dimensions have to match ({img_array.shape} != {shape})")
-    
-    img_array = img_array[:shape[0], :shape[1], :shape[2]]
+        raise ValueError(
+            f"Number of dimensions have to match ({img_array.shape} != {shape})"
+        )
+
+    img_array = img_array[: shape[0], : shape[1], : shape[2]]
     img_pads = [(0, max(0, n - img_array.shape[i])) for i, n in enumerate(shape)]
-    img_array = np.pad(img_array, img_pads, mode='constant', constant_values=padding_value)
-    
+    img_array = np.pad(
+        img_array, img_pads, mode="constant", constant_values=padding_value
+    )
+
     return img_array
 
+
 def generate_window_polygon(datasource: DatasetReader, window: Window) -> Polygon:
-    """
-    Turns the spatial bounds of a given window to a shapely.Polygon 
-    object in a given dataset's CRS.
-    
-    :param datasource: a rasterio DatasetReader object that provides the affine transformation
+    """Turns the spatial bounds of a given window to a shapely.Polygon object
+    in a given dataset's CRS.
+
+    :param datasource: a rasterio DatasetReader object that provides the
+        affine transformation
     :param window: bounds to represent as Polygon
-    :return: shapely Polygon representing the spatial bounds of a given window in a given CRS
+    :return: shapely Polygon representing the spatial bounds of a given
+        window in a given CRS
     """
 
     window_transform = datasource.window_transform(window)
@@ -88,11 +113,12 @@ def generate_window_polygon(datasource: DatasetReader, window: Window) -> Polygo
     window_poly = box(*window_bounds)
     return window_poly
 
-def generate_window_offsets(window: Window, schema: WindowSchema) -> np.ndarray:
-    """
-    Computes an array of window offsets bound by a given window.
 
-    :param window: the bounding window (i.e. offsets will be within its bounds)
+def generate_window_offsets(window: Window, schema: WindowSchema) -> np.ndarray:
+    """Computes an array of window offsets bound by a given window.
+
+    :param window: the bounding window (i.e. offsets will be within its
+        bounds)
     :param schema: the parameters for the window generator
     :return: an array of window offsets within the bounds of window
     """
@@ -100,12 +126,12 @@ def generate_window_offsets(window: Window, schema: WindowSchema) -> np.ndarray:
     col_range: np.ndarray = np.arange(
         np.max((0, window.col_off - schema.width_overlap)),
         window.width + window.col_off - schema.width_overlap,
-        schema.width_step
+        schema.width_step,
     )
     row_range: np.ndarray = np.arange(
         np.max((0, window.row_off - schema.height_overlap)),
         window.height + window.row_off - schema.height_overlap,
-        schema.height_step
+        schema.height_step,
     )
 
     window_offsets = np.array(np.meshgrid(col_range, row_range))
@@ -114,18 +140,22 @@ def generate_window_offsets(window: Window, schema: WindowSchema) -> np.ndarray:
     return window_offsets
 
 
-def window_factory(parent_window: Window, schema: WindowSchema, boundless: bool = True) -> Generator[Window, None, None]:
-    """
-    Generator that produces rasterio.Window objects in predetermined steps, within the given Window.
+def window_factory(
+    parent_window: Window, schema: WindowSchema, boundless: bool = True
+) -> Generator[Window, None, None]:
+    """Generator that produces rasterio.Window objects in predetermined steps,
+    within the given Window.
 
-    :param parent_window: the window that provides the bounds for all child_window objects
+    :param parent_window: the window that provides the bounds for all
+        child_window objects
     :param schema: the parameters that determine the window steps
-    :param boundless: whether the child_window should be clipped by the parent_window or not
+    :param boundless: whether the child_window should be clipped by the
+        parent_window or not
     :yield: a rasterio.Window used for windowed reading/writing
     """
-    
+
     window_offsets = generate_window_offsets(window=parent_window, schema=schema)
-    
+
     for col_off, row_off in window_offsets:
         child_window = Window(
             col_off=int(col_off),
@@ -138,34 +168,47 @@ def window_factory(parent_window: Window, schema: WindowSchema, boundless: bool 
 
         yield child_window
 
-def estimate_average_bounds(gdf: gpd.GeoDataFrame, quantile : float = 0.9) -> Tuple[float, float]:
-    """
-    Estimates the average size of all features in a GeoDataFrame.
-    
-    :param gdf: GeoDataFrame that contains all features (i.e. shapely.Geometry objects)
-    :param quantile: what quantile will represent the feature population  
+
+def estimate_average_bounds(
+    gdf: gpd.GeoDataFrame, quantile: float = 0.9
+) -> Tuple[float, float]:
+    """Estimates the average size of all features in a GeoDataFrame.
+
+    :param gdf: GeoDataFrame that contains all features (i.e.
+        shapely.Geometry objects)
+    :param quantile: what quantile will represent the feature population
     :return: a tuple of floats representing average width and height
     """
 
     label_bounds = gdf.bounds
-    label_widths = label_bounds.apply(lambda row: row['maxx'] - row['minx'], axis=1)
-    label_heights = label_bounds.apply(lambda row: row['maxy'] - row['miny'], axis=1)
+    label_widths = label_bounds.apply(lambda row: row["maxx"] - row["minx"], axis=1)
+    label_heights = label_bounds.apply(lambda row: row["maxy"] - row["miny"], axis=1)
     average_width = np.nanquantile(label_widths, quantile).astype(float)
     average_height = np.nanquantile(label_heights, quantile).astype(float)
-    
+
     return average_width, average_height
 
-def estimate_schema(gdf: gpd.GeoDataFrame, src: DatasetReader, quantile : float = 0.9, window_bounds:  List[Tuple[int, int]] = [(256, 256), (512, 512)]) -> WindowSchema:
-    """
-    Attempts to find a schema that is able to represent the average GeoDataFrame 
-    feature (i.e. sufficient overlap) but within the bounds given by window_bounds.
 
-    :param gdf: GeoDataFrame that contains features that determine the degree of overlap
-    :param src: The rasterio DataSource associated with the resulting schema (i.e. bounds and pixelsizes)
-    :param quantile: what quantile will represent the feature population  
-    :param window_bounds: a list of possible limits for the window generators
-    :return: (if found) a viable WindowSchema with sufficient overlap within the window_bounds
-    """    
+def estimate_schema(
+    gdf: gpd.GeoDataFrame,
+    src: DatasetReader,
+    quantile: float = 0.9,
+    window_bounds: List[Tuple[int, int]] = [(256, 256), (512, 512)],
+) -> WindowSchema:
+    """Attempts to find a schema that is able to represent the average
+    GeoDataFrame feature (i.e. sufficient overlap) but within the bounds given
+    by window_bounds.
+
+    :param gdf: GeoDataFrame that contains features that determine the
+        degree of overlap
+    :param src: The rasterio DataSource associated with the resulting
+        schema (i.e. bounds and pixelsizes)
+    :param quantile: what quantile will represent the feature population
+    :param window_bounds: a list of possible limits for the window
+        generators
+    :return: (if found) a viable WindowSchema with sufficient overlap
+        within the window_bounds
+    """
 
     # estimating the required overlap between windows for labels to be represented fully
     average_width, average_height = estimate_average_bounds(gdf=gdf, quantile=quantile)
@@ -183,15 +226,18 @@ def estimate_schema(gdf: gpd.GeoDataFrame, src: DatasetReader, quantile : float 
                 width_step=None,
                 height_window=height,
                 height_overlap=height_overlap,
-                height_step=None
-                )
+                height_step=None,
+            )
             break  # Break the loop as soon as a valid schema is found
-        
+
         except ValueError as value_error:
             last_exception = value_error
             continue
-        
+
     if schema is None:
-        raise ValueError(f"No WindowSchema objects could be created from the given window_bounds {window_bounds}, raising last Exception..") from last_exception
+        raise ValueError(
+            "No WindowSchema objects could be created from the given "
+            f"window_bounds {window_bounds}, raising last Exception.."
+        ) from last_exception
 
     return schema

--- a/geococo/utils.py
+++ b/geococo/utils.py
@@ -1,5 +1,4 @@
-import cv2
-from typing import Generator, List, Tuple, Dict, Optional, Union
+from typing import Generator, List, Tuple, Union
 import geopandas as gpd
 import numpy as np
 from rasterio.io import DatasetReader
@@ -9,9 +8,6 @@ from rasterio.errors import WindowError
 from rasterio.mask import mask as riomask
 from shapely.geometry import MultiPolygon, Polygon, box
 from geococo.window_schema import WindowSchema
-from numpy.ma import MaskedArray
-from pycocotools import mask as cocomask
-from geopandas.array import GeometryArray
 
 def mask_label(input_raster: DatasetReader, label: Union[Polygon, MultiPolygon]) -> np.ndarray:
 
@@ -101,12 +97,12 @@ def generate_window_offsets(window: Window, schema: WindowSchema) -> np.ndarray:
     :return: an array of window offsets within the bounds of window
     """
 
-    col_range = np.arange(
+    col_range: np.ndarray = np.arange(
         np.max((0, window.col_off - schema.width_overlap)),
         window.width + window.col_off - schema.width_overlap,
         schema.width_step
     )
-    row_range = np.arange(
+    row_range: np.ndarray = np.arange(
         np.max((0, window.row_off - schema.height_overlap)),
         window.height + window.row_off - schema.height_overlap,
         schema.height_step
@@ -184,8 +180,11 @@ def estimate_schema(gdf: gpd.GeoDataFrame, src: DatasetReader, quantile : float 
             schema = WindowSchema(
                 width_window=width,
                 width_overlap=width_overlap,
+                width_step=None,
                 height_window=height,
-                height_overlap=height_overlap)
+                height_overlap=height_overlap,
+                height_step=None
+                )
             break  # Break the loop as soon as a valid schema is found
         
         except ValueError as value_error:

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,6 +105,90 @@ files = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.2.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win32.whl", hash = "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win32.whl", hash = "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win32.whl", hash = "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win32.whl", hash = "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win32.whl", hash = "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80"},
+    {file = "charset_normalizer-3.2.0-py3-none-any.whl", hash = "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -246,6 +330,25 @@ files = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
+
+[[package]]
+name = "docformatter"
+version = "1.7.5"
+description = "Formats docstrings to follow PEP 257"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "docformatter-1.7.5-py3-none-any.whl", hash = "sha256:a24f5545ed1f30af00d106f5d85dc2fce4959295687c24c8f39f5263afaf9186"},
+    {file = "docformatter-1.7.5.tar.gz", hash = "sha256:ffed3da0daffa2e77f80ccba4f0e50bfa2755e1c10e130102571c890a61b246e"},
+]
+
+[package.dependencies]
+charset_normalizer = ">=3.0.0,<4.0.0"
+tomli = {version = ">=2.0.0,<3.0.0", optional = true, markers = "python_version < \"3.11\" and extra == \"tomli\""}
+untokenize = ">=0.1.1,<0.2.0"
+
+[package.extras]
+tomli = ["tomli (>=2.0.0,<3.0.0)"]
 
 [[package]]
 name = "docstring-parser"
@@ -1477,6 +1580,16 @@ files = [
 ]
 
 [[package]]
+name = "untokenize"
+version = "0.1.1"
+description = "Transforms tokens into original source code (while preserving whitespace)."
+optional = false
+python-versions = "*"
+files = [
+    {file = "untokenize-0.1.1.tar.gz", hash = "sha256:3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2"},
+]
+
+[[package]]
 name = "zipp"
 version = "3.16.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1494,4 +1607,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3e3e040f9a53f3cd9e98eaa5f31288a6ef6a485363ee523e3b7cbcfa3602810d"
+content-hash = "a22282e0f7e4c4d841753218efec819cf6b6eb9ee550310b354955e33976c774"

--- a/poetry.lock
+++ b/poetry.lock
@@ -441,79 +441,115 @@ files = [
 
 [[package]]
 name = "kiwisolver"
-version = "1.4.4"
+version = "1.4.5"
 description = "A fast implementation of the Cassowary constraint solver"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2f5e60fabb7343a836360c4f0919b8cd0d6dbf08ad2ca6b9cf90bf0c76a3c4f6"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10ee06759482c78bdb864f4109886dff7b8a56529bc1609d4f1112b93fe6423c"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c79ebe8f3676a4c6630fd3f777f3cfecf9289666c84e775a67d1d358578dc2e3"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:abbe9fa13da955feb8202e215c4018f4bb57469b1b78c7a4c5c7b93001699938"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7577c1987baa3adc4b3c62c33bd1118c3ef5c8ddef36f0f2c950ae0b199e100d"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8ad8285b01b0d4695102546b342b493b3ccc6781fc28c8c6a1bb63e95d22f09"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ed58b8acf29798b036d347791141767ccf65eee7f26bde03a71c944449e53de"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a68b62a02953b9841730db7797422f983935aeefceb1679f0fc85cbfbd311c32"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-win32.whl", hash = "sha256:e92a513161077b53447160b9bd8f522edfbed4bd9759e4c18ab05d7ef7e49408"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fe20f63c9ecee44560d0e7f116b3a747a5d7203376abeea292ab3152334d004"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e0ea21f66820452a3f5d1655f8704a60d66ba1191359b96541eaf457710a5fc6"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bc9db8a3efb3e403e4ecc6cd9489ea2bac94244f80c78e27c31dcc00d2790ac2"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d5b61785a9ce44e5a4b880272baa7cf6c8f48a5180c3e81c59553ba0cb0821ca"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2dbb44c3f7e6c4d3487b31037b1bdbf424d97687c1747ce4ff2895795c9bf69"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6295ecd49304dcf3bfbfa45d9a081c96509e95f4b9d0eb7ee4ec0530c4a96514"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4bd472dbe5e136f96a4b18f295d159d7f26fd399136f5b17b08c4e5f498cd494"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf7d9fce9bcc4752ca4a1b80aabd38f6d19009ea5cbda0e0856983cf6d0023f5"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d6601aed50c74e0ef02f4204da1816147a6d3fbdc8b3872d263338a9052c51"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:877272cf6b4b7e94c9614f9b10140e198d2186363728ed0f701c6eee1baec1da"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:db608a6757adabb32f1cfe6066e39b3706d8c3aa69bbc353a5b61edad36a5cb4"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:5853eb494c71e267912275e5586fe281444eb5e722de4e131cddf9d442615626"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:f0a1dbdb5ecbef0d34eb77e56fcb3e95bbd7e50835d9782a45df81cc46949750"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:283dffbf061a4ec60391d51e6155e372a1f7a4f5b15d59c8505339454f8989e4"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-win32.whl", hash = "sha256:d06adcfa62a4431d404c31216f0f8ac97397d799cd53800e9d3efc2fbb3cf14e"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:e7da3fec7408813a7cebc9e4ec55afed2d0fd65c4754bc376bf03498d4e92686"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:62ac9cc684da4cf1778d07a89bf5f81b35834cb96ca523d3a7fb32509380cbf6"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41dae968a94b1ef1897cb322b39360a0812661dba7c682aa45098eb8e193dbdf"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02f79693ec433cb4b5f51694e8477ae83b3205768a6fb48ffba60549080e295b"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d0611a0a2a518464c05ddd5a3a1a0e856ccc10e67079bb17f265ad19ab3c7597"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:db5283d90da4174865d520e7366801a93777201e91e79bacbac6e6927cbceede"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1041feb4cda8708ce73bb4dcb9ce1ccf49d553bf87c3954bdfa46f0c3f77252c"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-win32.whl", hash = "sha256:a553dadda40fef6bfa1456dc4be49b113aa92c2a9a9e8711e955618cd69622e3"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:03baab2d6b4a54ddbb43bba1a3a2d1627e82d205c5cf8f4c924dc49284b87166"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:841293b17ad704d70c578f1f0013c890e219952169ce8a24ebc063eecf775454"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f4f270de01dd3e129a72efad823da90cc4d6aafb64c410c9033aba70db9f1ff0"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f9f39e2f049db33a908319cf46624a569b36983c7c78318e9726a4cb8923b26c"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c97528e64cb9ebeff9701e7938653a9951922f2a38bd847787d4a8e498cc83ae"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d1573129aa0fd901076e2bfb4275a35f5b7aa60fbfb984499d661ec950320b0"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad881edc7ccb9d65b0224f4e4d05a1e85cf62d73aab798943df6d48ab0cd79a1"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b428ef021242344340460fa4c9185d0b1f66fbdbfecc6c63eff4b7c29fad429d"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2e407cb4bd5a13984a6c2c0fe1845e4e41e96f183e5e5cd4d77a857d9693494c"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-win32.whl", hash = "sha256:75facbe9606748f43428fc91a43edb46c7ff68889b91fa31f53b58894503a191"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bce61af018b0cb2055e0e72e7d65290d822d3feee430b7b8203d8a855e78766"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8c808594c88a025d4e322d5bb549282c93c8e1ba71b790f539567932722d7bd8"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0a71d85ecdd570ded8ac3d1c0f480842f49a40beb423bb8014539a9f32a5897"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b533558eae785e33e8c148a8d9921692a9fe5aa516efbdff8606e7d87b9d5824"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:efda5fc8cc1c61e4f639b8067d118e742b812c930f708e6667a5ce0d13499e29"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7c43e1e1206cd421cd92e6b3280d4385d41d7166b3ed577ac20444b6995a445f"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc8d3bd6c72b2dd9decf16ce70e20abcb3274ba01b4e1c96031e0c4067d1e7cd"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4ea39b0ccc4f5d803e3337dd46bcce60b702be4d86fd0b3d7531ef10fd99a1ac"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:968f44fdbf6dd757d12920d63b566eeb4d5b395fd2d00d29d7ef00a00582aac9"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-win32.whl", hash = "sha256:da7e547706e69e45d95e116e6939488d62174e033b763ab1496b4c29b76fabea"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:ba59c92039ec0a66103b1d5fe588fa546373587a7d68f5c96f743c3396afc04b"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:91672bacaa030f92fc2f43b620d7b337fd9a5af28b0d6ed3f77afc43c4a64b5a"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:787518a6789009c159453da4d6b683f468ef7a65bbde796bcea803ccf191058d"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da152d8cdcab0e56e4f45eb08b9aea6455845ec83172092f09b0e077ece2cf7a"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ecb1fa0db7bf4cff9dac752abb19505a233c7f16684c5826d1f11ebd9472b871"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:28bc5b299f48150b5f822ce68624e445040595a4ac3d59251703779836eceff9"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:81e38381b782cc7e1e46c4e14cd997ee6040768101aefc8fa3c24a4cc58e98f8"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2a66fdfb34e05b705620dd567f5a03f239a088d5a3f321e7b6ac3239d22aa286"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:872b8ca05c40d309ed13eb2e582cab0c5a05e81e987ab9c521bf05ad1d5cf5cb"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:70e7c2e7b750585569564e2e5ca9845acfaa5da56ac46df68414f29fea97be9f"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9f85003f5dfa867e86d53fac6f7e6f30c045673fa27b603c397753bebadc3008"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e307eb9bd99801f82789b44bb45e9f541961831c7311521b13a6c85afc09767"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1792d939ec70abe76f5054d3f36ed5656021dcad1322d1cc996d4e54165cef9"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6cb459eea32a4e2cf18ba5fcece2dbdf496384413bc1bae15583f19e567f3b2"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:36dafec3d6d6088d34e2de6b85f9d8e2324eb734162fba59d2ba9ed7a2043d5b"},
-    {file = "kiwisolver-1.4.4.tar.gz", hash = "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:05703cf211d585109fcd72207a31bb170a0f22144d68298dc5e61b3c946518af"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:146d14bebb7f1dc4d5fbf74f8a6cb15ac42baadee8912eb84ac0b3b2a3dc6ac3"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ef7afcd2d281494c0a9101d5c571970708ad911d028137cd558f02b851c08b4"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9eaa8b117dc8337728e834b9c6e2611f10c79e38f65157c4c38e9400286f5cb1"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec20916e7b4cbfb1f12380e46486ec4bcbaa91a9c448b97023fde0d5bbf9e4ff"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39b42c68602539407884cf70d6a480a469b93b81b7701378ba5e2328660c847a"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aa12042de0171fad672b6c59df69106d20d5596e4f87b5e8f76df757a7c399aa"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2a40773c71d7ccdd3798f6489aaac9eee213d566850a9533f8d26332d626b82c"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:19df6e621f6d8b4b9c4d45f40a66839294ff2bb235e64d2178f7522d9170ac5b"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:83d78376d0d4fd884e2c114d0621624b73d2aba4e2788182d286309ebdeed770"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:e391b1f0a8a5a10ab3b9bb6afcfd74f2175f24f8975fb87ecae700d1503cdee0"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:852542f9481f4a62dbb5dd99e8ab7aedfeb8fb6342349a181d4036877410f525"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59edc41b24031bc25108e210c0def6f6c2191210492a972d585a06ff246bb79b"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-win32.whl", hash = "sha256:a6aa6315319a052b4ee378aa171959c898a6183f15c1e541821c5c59beaa0238"},
+    {file = "kiwisolver-1.4.5-cp310-cp310-win_amd64.whl", hash = "sha256:d0ef46024e6a3d79c01ff13801cb19d0cad7fd859b15037aec74315540acc276"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:11863aa14a51fd6ec28688d76f1735f8f69ab1fabf388851a595d0721af042f5"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ab3919a9997ab7ef2fbbed0cc99bb28d3c13e6d4b1ad36e97e482558a91be90"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fcc700eadbbccbf6bc1bcb9dbe0786b4b1cb91ca0dcda336eef5c2beed37b797"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dfdd7c0b105af050eb3d64997809dc21da247cf44e63dc73ff0fd20b96be55a9"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c6a5964640638cdeaa0c359382e5703e9293030fe730018ca06bc2010c4437"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bbea0db94288e29afcc4c28afbf3a7ccaf2d7e027489c449cf7e8f83c6346eb9"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ceec1a6bc6cab1d6ff5d06592a91a692f90ec7505d6463a88a52cc0eb58545da"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:040c1aebeda72197ef477a906782b5ab0d387642e93bda547336b8957c61022e"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f91de7223d4c7b793867797bacd1ee53bfe7359bd70d27b7b58a04efbb9436c8"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:faae4860798c31530dd184046a900e652c95513796ef51a12bc086710c2eec4d"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b0157420efcb803e71d1b28e2c287518b8808b7cf1ab8af36718fd0a2c453eb0"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:06f54715b7737c2fecdbf140d1afb11a33d59508a47bf11bb38ecf21dc9ab79f"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fdb7adb641a0d13bdcd4ef48e062363d8a9ad4a182ac7647ec88f695e719ae9f"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-win32.whl", hash = "sha256:bb86433b1cfe686da83ce32a9d3a8dd308e85c76b60896d58f082136f10bffac"},
+    {file = "kiwisolver-1.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:6c08e1312a9cf1074d17b17728d3dfce2a5125b2d791527f33ffbe805200a355"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:32d5cf40c4f7c7b3ca500f8985eb3fb3a7dfc023215e876f207956b5ea26632a"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f846c260f483d1fd217fe5ed7c173fb109efa6b1fc8381c8b7552c5781756192"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5ff5cf3571589b6d13bfbfd6bcd7a3f659e42f96b5fd1c4830c4cf21d4f5ef45"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7269d9e5f1084a653d575c7ec012ff57f0c042258bf5db0954bf551c158466e7"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da802a19d6e15dffe4b0c24b38b3af68e6c1a68e6e1d8f30148c83864f3881db"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3aba7311af82e335dd1e36ffff68aaca609ca6290c2cb6d821a39aa075d8e3ff"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:763773d53f07244148ccac5b084da5adb90bfaee39c197554f01b286cf869228"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2270953c0d8cdab5d422bee7d2007f043473f9d2999631c86a223c9db56cbd16"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d099e745a512f7e3bbe7249ca835f4d357c586d78d79ae8f1dcd4d8adeb9bda9"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:74db36e14a7d1ce0986fa104f7d5637aea5c82ca6326ed0ec5694280942d1162"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:7e5bab140c309cb3a6ce373a9e71eb7e4873c70c2dda01df6820474f9889d6d4"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:0f114aa76dc1b8f636d077979c0ac22e7cd8f3493abbab152f20eb8d3cda71f3"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:88a2df29d4724b9237fc0c6eaf2a1adae0cdc0b3e9f4d8e7dc54b16812d2d81a"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-win32.whl", hash = "sha256:72d40b33e834371fd330fb1472ca19d9b8327acb79a5821d4008391db8e29f20"},
+    {file = "kiwisolver-1.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:2c5674c4e74d939b9d91dda0fae10597ac7521768fec9e399c70a1f27e2ea2d9"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3a2b053a0ab7a3960c98725cfb0bf5b48ba82f64ec95fe06f1d06c99b552e130"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cd32d6c13807e5c66a7cbb79f90b553642f296ae4518a60d8d76243b0ad2898"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59ec7b7c7e1a61061850d53aaf8e93db63dce0c936db1fda2658b70e4a1be709"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da4cfb373035def307905d05041c1d06d8936452fe89d464743ae7fb8371078b"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2400873bccc260b6ae184b2b8a4fec0e4082d30648eadb7c3d9a13405d861e89"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1b04139c4236a0f3aff534479b58f6f849a8b351e1314826c2d230849ed48985"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:4e66e81a5779b65ac21764c295087de82235597a2293d18d943f8e9e32746265"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7931d8f1f67c4be9ba1dd9c451fb0eeca1a25b89e4d3f89e828fe12a519b782a"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:b3f7e75f3015df442238cca659f8baa5f42ce2a8582727981cbfa15fee0ee205"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:bbf1d63eef84b2e8c89011b7f2235b1e0bf7dacc11cac9431fc6468e99ac77fb"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4c380469bd3f970ef677bf2bcba2b6b0b4d5c75e7a020fb863ef75084efad66f"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-win32.whl", hash = "sha256:9408acf3270c4b6baad483865191e3e582b638b1654a007c62e3efe96f09a9a3"},
+    {file = "kiwisolver-1.4.5-cp37-cp37m-win_amd64.whl", hash = "sha256:5b94529f9b2591b7af5f3e0e730a4e0a41ea174af35a4fd067775f9bdfeee01a"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:11c7de8f692fc99816e8ac50d1d1aef4f75126eefc33ac79aac02c099fd3db71"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:53abb58632235cd154176ced1ae8f0d29a6657aa1aa9decf50b899b755bc2b93"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:88b9f257ca61b838b6f8094a62418421f87ac2a1069f7e896c36a7d86b5d4c29"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3195782b26fc03aa9c6913d5bad5aeb864bdc372924c093b0f1cebad603dd712"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc579bf0f502e54926519451b920e875f433aceb4624a3646b3252b5caa9e0b6"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a580c91d686376f0f7c295357595c5a026e6cbc3d77b7c36e290201e7c11ecb"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cfe6ab8da05c01ba6fbea630377b5da2cd9bcbc6338510116b01c1bc939a2c18"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d2e5a98f0ec99beb3c10e13b387f8db39106d53993f498b295f0c914328b1333"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:a51a263952b1429e429ff236d2f5a21c5125437861baeed77f5e1cc2d2c7c6da"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3edd2fa14e68c9be82c5b16689e8d63d89fe927e56debd6e1dbce7a26a17f81b"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:74d1b44c6cfc897df648cc9fdaa09bc3e7679926e6f96df05775d4fb3946571c"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:76d9289ed3f7501012e05abb8358bbb129149dbd173f1f57a1bf1c22d19ab7cc"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:92dea1ffe3714fa8eb6a314d2b3c773208d865a0e0d35e713ec54eea08a66250"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-win32.whl", hash = "sha256:5c90ae8c8d32e472be041e76f9d2f2dbff4d0b0be8bd4041770eddb18cf49a4e"},
+    {file = "kiwisolver-1.4.5-cp38-cp38-win_amd64.whl", hash = "sha256:c7940c1dc63eb37a67721b10d703247552416f719c4188c54e04334321351ced"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9407b6a5f0d675e8a827ad8742e1d6b49d9c1a1da5d952a67d50ef5f4170b18d"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15568384086b6df3c65353820a4473575dbad192e35010f622c6ce3eebd57af9"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0dc9db8e79f0036e8173c466d21ef18e1befc02de8bf8aa8dc0813a6dc8a7046"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:cdc8a402aaee9a798b50d8b827d7ecf75edc5fb35ea0f91f213ff927c15f4ff0"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6c3bd3cde54cafb87d74d8db50b909705c62b17c2099b8f2e25b461882e544ff"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:955e8513d07a283056b1396e9a57ceddbd272d9252c14f154d450d227606eb54"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:346f5343b9e3f00b8db8ba359350eb124b98c99efd0b408728ac6ebf38173958"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9098e0049e88c6a24ff64545cdfc50807818ba6c1b739cae221bbbcbc58aad3"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:00bd361b903dc4bbf4eb165f24d1acbee754fce22ded24c3d56eec268658a5cf"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7b8b454bac16428b22560d0a1cf0a09875339cab69df61d7805bf48919415901"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:f1d072c2eb0ad60d4c183f3fb44ac6f73fb7a8f16a2694a91f988275cbf352f9"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:31a82d498054cac9f6d0b53d02bb85811185bcb477d4b60144f915f3b3126342"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6512cb89e334e4700febbffaaa52761b65b4f5a3cf33f960213d5656cea36a77"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-win32.whl", hash = "sha256:9db8ea4c388fdb0f780fe91346fd438657ea602d58348753d9fb265ce1bca67f"},
+    {file = "kiwisolver-1.4.5-cp39-cp39-win_amd64.whl", hash = "sha256:59415f46a37f7f2efeec758353dd2eae1b07640d8ca0f0c42548ec4125492635"},
+    {file = "kiwisolver-1.4.5-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5c7b3b3a728dc6faf3fc372ef24f21d1e3cee2ac3e9596691d746e5a536de920"},
+    {file = "kiwisolver-1.4.5-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:620ced262a86244e2be10a676b646f29c34537d0d9cc8eb26c08f53d98013390"},
+    {file = "kiwisolver-1.4.5-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:378a214a1e3bbf5ac4a8708304318b4f890da88c9e6a07699c4ae7174c09a68d"},
+    {file = "kiwisolver-1.4.5-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaf7be1207676ac608a50cd08f102f6742dbfc70e8d60c4db1c6897f62f71523"},
+    {file = "kiwisolver-1.4.5-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ba55dce0a9b8ff59495ddd050a0225d58bd0983d09f87cfe2b6aec4f2c1234e4"},
+    {file = "kiwisolver-1.4.5-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fd32ea360bcbb92d28933fc05ed09bffcb1704ba3fc7942e81db0fd4f81a7892"},
+    {file = "kiwisolver-1.4.5-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5e7139af55d1688f8b960ee9ad5adafc4ac17c1c473fe07133ac092310d76544"},
+    {file = "kiwisolver-1.4.5-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dced8146011d2bc2e883f9bd68618b8247387f4bbec46d7392b3c3b032640126"},
+    {file = "kiwisolver-1.4.5-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9bf3325c47b11b2e51bca0824ea217c7cd84491d8ac4eefd1e409705ef092bd"},
+    {file = "kiwisolver-1.4.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:5794cf59533bc3f1b1c821f7206a3617999db9fbefc345360aafe2e067514929"},
+    {file = "kiwisolver-1.4.5-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e368f200bbc2e4f905b8e71eb38b3c04333bddaa6a2464a6355487b02bb7fb09"},
+    {file = "kiwisolver-1.4.5-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5d706eba36b4c4d5bc6c6377bb6568098765e990cfc21ee16d13963fab7b3e7"},
+    {file = "kiwisolver-1.4.5-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85267bd1aa8880a9c88a8cb71e18d3d64d2751a790e6ca6c27b8ccc724bcd5ad"},
+    {file = "kiwisolver-1.4.5-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210ef2c3a1f03272649aff1ef992df2e724748918c4bc2d5a90352849eb40bea"},
+    {file = "kiwisolver-1.4.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:11d011a7574eb3b82bcc9c1a1d35c1d7075677fdd15de527d91b46bd35e935ee"},
+    {file = "kiwisolver-1.4.5.tar.gz", hash = "sha256:e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec"},
 ]
 
 [[package]]
@@ -873,13 +909,13 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-co
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
 
 [package.extras]
@@ -921,18 +957,18 @@ numpy = "*"
 
 [[package]]
 name = "pydantic"
-version = "2.2.1"
+version = "2.3.0"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-2.2.1-py3-none-any.whl", hash = "sha256:0c88bd2b63ed7a5109c75ab180d55f58f80a4b559682406812d0684d3f4b9192"},
-    {file = "pydantic-2.2.1.tar.gz", hash = "sha256:31b5cada74b2320999fb2577e6df80332a200ff92e7775a52448b6b036fce24a"},
+    {file = "pydantic-2.3.0-py3-none-any.whl", hash = "sha256:45b5e446c6dfaad9444819a293b921a40e1db1aa61ea08aede0522529ce90e81"},
+    {file = "pydantic-2.3.0.tar.gz", hash = "sha256:1607cc106602284cd4a00882986570472f193fde9cb1259bceeaedb26aa79a6d"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.4.0"
-pydantic-core = "2.6.1"
+pydantic-core = "2.6.3"
 typing-extensions = ">=4.6.1"
 
 [package.extras]
@@ -940,117 +976,117 @@ email = ["email-validator (>=2.0.0)"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.6.1"
+version = "2.6.3"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic_core-2.6.1-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:f55001a689111a297c0006c46c0589cfd559261baaa9a37bc35eff05b8cae1a6"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bb6273068e9450c5c91f58dd277fbd406b896ffa30f0ef312edc5519d07f16ae"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:043212f21c75cb6ee3a92fffbc747410e32b08e1a419ce16a9da98a16d660a7c"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db0c12f1e9d3bf658634621f3423486803d749fef77a64cfb4252f9d619e1817"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81424dc05c4342a19fb64323bb9d4468e7407b745c00377ccc4d3dd96d5e02fe"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3c8f3aebaf92f088b1dafd7101d1ccca0459ae0f5b26017411b9969667d289a9"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd9f14454b4bc89c705ce17951f9c783db82efd2b44a424487c593e2269eef61"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2effc71653247e76c5b95d15c58d4ca3f591f42f714eb3b32df9d6ec613794a5"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:56672429f8a89d2a0f4402d912f0dad68c2d05f7c278d3152c6fb4a76c2a429a"},
-    {file = "pydantic_core-2.6.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d0bf1c2545ab253732229c7fe8294d98eb08f99aa25a388267e1bc4d2d7e0a34"},
-    {file = "pydantic_core-2.6.1-cp310-none-win32.whl", hash = "sha256:c5be947ad41a7602f941dc834d03e64dd1c7fae65fa85cb4f1004a95c5d50df1"},
-    {file = "pydantic_core-2.6.1-cp310-none-win_amd64.whl", hash = "sha256:3d14ae98a8d251402ef8ed017039d2fc3e29fb155f909cd3816ba259fd30fb48"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:4a3c20808d3ced90e29439f72a563eadf21d29560935cc818b2dab80b92c114a"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:da240bbd8191edc6009e7793d5d4d67c55f56225c4788f068d6286c20e5a2038"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de1a3e56e34264d5216c67d2a48185216ada8f5f35a7f4c96a3971847c0de897"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9b623e09239ed333d14c02c9fcd1a7bb350b95eca8383f6e9b0d8e373d5a14b5"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a12520a6d502a25f6e47319874e47056b290f1b3c2ed9391444ce81c8cc5b83"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d1141f18414aee8865c7917ae1432e419c1983272f53625152493692ff3d6783"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7888b3ee7566865cff3e9edab5d6cdf2e7cf793df17fe53d5e7be3e57eae45ec"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bdf293b6304bc451678b7016c2505b7d97aa85ff13dac4420027b1b69e15d3d"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7ef56a05bb60336d5e795bf166d6712b2362e6478522c77e8336cb0da8909913"},
-    {file = "pydantic_core-2.6.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3210eb73707e3487c16ef25cfd1663660f4e7d647a181d6c2fb18bc6167985fb"},
-    {file = "pydantic_core-2.6.1-cp311-none-win32.whl", hash = "sha256:707e3005e8c129bdac117285b71717c13b9ed81a81eae0b1642f4ddc60028e63"},
-    {file = "pydantic_core-2.6.1-cp311-none-win_amd64.whl", hash = "sha256:2b8ccec2189d8a8b83929f79e5bc00c0656f6c2ba4345125c0c82d1b77e15a26"},
-    {file = "pydantic_core-2.6.1-cp311-none-win_arm64.whl", hash = "sha256:c1e44b77442fb5b1b6fccea30e3359b14d0a2e5896801243defe54482a591500"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:c82fb25f965f6777032fc2f2856c86149f7709c8f7fd0c020a8631b8211f2bab"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:494b211b12b8fedd184dbba609f6ed582e23561db57c1996fd6773989dbaef9b"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1281c940f47e5c89b594ef7580045647df1f9ad687edd503bcc0485be94576f4"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2d41701c88d8b678c16c10562949f2d28aceacd767cbe51dac9c8c41e6e609fb"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6a839c95d5cc91eed053d8dafde4e200c4bc82f56fb1cf7bbfaeb03e2d907929"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22e4fbfb5823d0fcb2c20ed164b39c3588554f9635f70765e8c9cff0fef67ad"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2fed4ad60ccf2698bd04e95dfc3bd84149ced9605a29fd27d624701e1da300c"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33b9343aa464d60c31937b361abde08d3af9943f3eb09d3216211b6236bd40c4"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:56e4953cd911293d6d755e2a97c651826aca76201db8f1ee298939e703721390"},
-    {file = "pydantic_core-2.6.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cd163109047ab41ef1ea34258b35beb3ccac90af2012927ee8ab6ff122fef671"},
-    {file = "pydantic_core-2.6.1-cp312-none-win32.whl", hash = "sha256:f5b51ec04743c94288c46e3759769611ab7c5ce0f941113363da96d20d345fb6"},
-    {file = "pydantic_core-2.6.1-cp312-none-win_amd64.whl", hash = "sha256:ca5606bd82e255b1d704a4334e5ebf05ae966b69686fae02dcd31c057bdcb113"},
-    {file = "pydantic_core-2.6.1-cp312-none-win_arm64.whl", hash = "sha256:dfc8f534a21b60b00f87e5a4fc36b8b8945160a6cc9e7b6e67db541c766c9597"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:b1aed20778092f8334c8eaf91550fa2805221d5e9b40ebdd1f46ee7efc159a48"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:64ff7a4b7ee2a56735af28da76c5dacbba6995801080f739d14610f4aa3de35d"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2d8faedb138c704957642fdf154c94f1b3d2a15cbd2472e45665f80463e85ee"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:55aac69d7339a63e37164f0a629c3034becc6746d68d126118a3ee4493514bed"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dfdb1617af455a551be4cc0471f0bf3bfb1e882db71afad0e587c821326bb749"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aadc84f5bd7b1421b5a6b389ceff46062dd4a58c44cfb75990e9ca2d9d8270df"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1a01dce87507b9a8f1b71933ade85c573a22c9bd4649590e28d8a497afb68bd"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd6f05f3e237ed6b3949464e7679e55843645fe0fe8d3b33277c321386836f6a"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:760f8a0aeb43ceeff1e536859e071a72e91075d4d37d51470812c4f49e682702"},
-    {file = "pydantic_core-2.6.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a1ad48e77935d7dbbc2d75aeb638abbfbd0df0cfacf774dbe98d52271468f00c"},
-    {file = "pydantic_core-2.6.1-cp37-none-win32.whl", hash = "sha256:153a5dd24c09ab7544beda967366afbaae8350b327a4ebd5807ed45ec791baa0"},
-    {file = "pydantic_core-2.6.1-cp37-none-win_amd64.whl", hash = "sha256:cc7fc3e81b4ea6bce7e0e1d9797f496e957c5e66adf483f89afdce2d81d19986"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:5482d692ae37857695feccb179022728b275b7bfcc1c85bcdf7b556e76bffcd8"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:45d248c3c5c5c23a8d048cfdebc8151ae7b32a6dc6d68fbca995521e54692207"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dd6c9f47e26779bf1f7da4d6ccd60f66973e63b0a143438f1e20bae296c3fde"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:55701608e60418a423db2486b5c64d790f86eb78a11b9077efb6302c50e62564"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:420a76a62dd20a6ef08445abf7cf04dcd8a845a5bb15932c2e88a8e518c70d43"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f253d20314e53ba0fb2b95541b6ed23f44fbcd927fe7674de341545c3327c3d"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5127b811c6a26deb85f5b17a06c26c28ce204e51e0a963b75bdf8612b22546d"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:51ffa985b874ca7d0dc199bb75c67b77907379291c91532a9e2d981f7b681527"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4902300e763a2fcc49ae14366493ef1fdbd3c7128b9acf37aef505f671aa681f"},
-    {file = "pydantic_core-2.6.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e1c69334bb843c9bff98f52a1fa6c06420081a561fcecb03c6b9376960bd7de2"},
-    {file = "pydantic_core-2.6.1-cp38-none-win32.whl", hash = "sha256:e84812b1ca989b2e9f4913d7b75ae0eece2a90154de35b4c5411ad640bfd387c"},
-    {file = "pydantic_core-2.6.1-cp38-none-win_amd64.whl", hash = "sha256:775098e3629a959dfec8444667a53e0916839e9fbf6b55e07d6e2aadde006400"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:a32ed5a794918a61bf77b967c197eb78f31ad4e3145860193dc381bde040717e"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:66eda8ac48ac33e9e5c6541c8e30c702924b70a6f2e9732b74230d9b2dd35fb6"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb5131d75d69b0547ef9a8f46f7b94857411c9badcdd5092de61a3b4943f08c7"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e850f3242d7836a5e15453f798d8569b9754350c8e184ba32d102c515dd507"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f4327fa6a1ac3da62b27d43bb0f27657ed4e601b141ecbfcf8523814b6c33b6"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c7b89b2875b967ad5c3c980bf72773851554f80c2529796e815a10c99295d872"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78eadd8d7d5cd8c3616e363c394d721437c339feaa4c28404e2eda79add69781"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:17ab25bb24e98b61d120b7248c2b49ea56ce754a050d6b348be42015fcb7aa25"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6ea8dd2854fe6cee5ea0d60304ee7877dffe487cf118f221e85029269dd1235d"},
-    {file = "pydantic_core-2.6.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9bf3ba6b4878ee692f6e24230801f682807fd97356bc2064f630fc0a2ad2ead6"},
-    {file = "pydantic_core-2.6.1-cp39-none-win32.whl", hash = "sha256:b974d65692333931b4c7f730e7a3135ff854a1e5384bc260de3327ea364c835a"},
-    {file = "pydantic_core-2.6.1-cp39-none-win_amd64.whl", hash = "sha256:f34f26d8a5f1a45366189ec30a57f43b21e2172d0d3b62822638dd885cc8eaab"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:f7ec4c6edafa3f0eb1aa461e31ea263736cc541b2459dddfbda7085b30844801"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:3679b9a1f41eb1b699e9556f91281d78c416cdc59ae90d5733fbe2017f1effe9"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3ff36f945342086ee917d4219dd0e59660a2dfcdb86a07696c2791f5d59c07d"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:734864605d722a6f8db3b9c96371710f7cb591fbfca40cfeaedf5b67df282438"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7188359b95a2b1aef5744a2ee6af2d9cfc733dd823f8840f4c896129477a172b"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:382d40843ae759d43ef65b67dec713390f9417135c1dd730afbf03cf2f450f45"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:4525b8498d362e4e324e3e175239b364768f52bd3563ac4ef9750160f5789de8"},
-    {file = "pydantic_core-2.6.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e55514a022c768cccf07a675d20d07b847980dcd9250f6b516a86bab5612fc01"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:34734d486d059f0f6f5bfa9ba4a41449f666e2abbde002e9fa8b050bc50e3347"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a809498dceb0cd1cd1e57a2bfdc70ea82f424776e0196f4d63c4b6fcdaeb5aab"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:588a5ffd8bbf1b2230611ed1b45221adcf05b981037b2f853b5f20465849b5c1"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:26b81017aeae0d96f776fbce34a3a763d26ac575d8ad3f1202bdfdd2b935954b"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:7ddaa2c3c66682f0ff4ebc8c85ef2d8305f32deba79416464c47c93d94ca3740"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:d6971131de66d1a37293f2e032206b6984b0dec44f568b453dfe89a84a2de0cc"},
-    {file = "pydantic_core-2.6.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:200704f6824f8014bdccb1ce57cbd328666e6de4ecd77f0b8ab472cdea9c49ce"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:6916b27072c957947919fb32551f08486562bb8616f2e3db9e4e9c1d83d36886"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:136de286abf53f326b90389aaaca8a8050c2570adfc74afe06ab1c35d5d242bf"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60a238bb4ab09a81a6b25c9a0bb12756cfab2d9f3a7a471f857a179f83da0df6"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2034d9b83a59b3b74b9dbf97ddb99de86c08863c1c33aabf80bc95791c7d50c3"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7c3a2b4d1636446dc71da1e949d2cf9ac1ee691ca63a640b77fce0360b4b75be"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:09e4ebd11a0b333b1fca75c1004c76dc9719f3aaf83ae38c42358754d8a76148"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:a4536d132a8bbd05bf368fb802a264cb9828f6c85e4029a6a3670bc98ba97323"},
-    {file = "pydantic_core-2.6.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:6221c97d6d58f2370650cfe3d81408901a1951c99960e1df9f6f9f8482d73d08"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:4223e8bdad41d846a84cda400cd538e1cdc63d98eb4d41951396bfdb88fd8ce9"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c07cdb2e02733e5f26b9b004a1a8b99814d175f8953fa9f59e4293de2b8e9787"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8714e958d01342d08e520ffec6c1acf66cdec83ce51302f9a1a6efb2f784d0b6"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f03541c25a77fb5445055e070b69d292c9818a9195ffbfd3962c0ad0da983e8"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:364c13ef48c9e2f8c2ea8ee0da5ea23db5e218f99e796cbf360a2a7cab511439"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:27ba58bbfd1b2b9da45bfe524e680e2bc747a1ca9738ee5aa18d8cbdcc08e5e6"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:92321582e59da185b76b2eca4488ea95e41800672e57107509d32ebf8ad550f8"},
-    {file = "pydantic_core-2.6.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2da1d21a4f2675d5b8a749674993a65c0537e2066e7ab7b1a4a54ef0b3ac8efd"},
-    {file = "pydantic_core-2.6.1.tar.gz", hash = "sha256:5b4efa68bcfa6f2b93624c6660b6cf4b7b4336d4225afb314254a0ed9c9f4153"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:1a0ddaa723c48af27d19f27f1c73bdc615c73686d763388c8683fe34ae777bad"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5cfde4fab34dd1e3a3f7f3db38182ab6c95e4ea91cf322242ee0be5c2f7e3d2f"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5493a7027bfc6b108e17c3383959485087d5942e87eb62bbac69829eae9bc1f7"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84e87c16f582f5c753b7f39a71bd6647255512191be2d2dbf49458c4ef024588"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:522a9c4a4d1924facce7270c84b5134c5cabcb01513213662a2e89cf28c1d309"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aaafc776e5edc72b3cad1ccedb5fd869cc5c9a591f1213aa9eba31a781be9ac1"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a750a83b2728299ca12e003d73d1264ad0440f60f4fc9cee54acc489249b728"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9e8b374ef41ad5c461efb7a140ce4730661aadf85958b5c6a3e9cf4e040ff4bb"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b594b64e8568cf09ee5c9501ede37066b9fc41d83d58f55b9952e32141256acd"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2a20c533cb80466c1d42a43a4521669ccad7cf2967830ac62c2c2f9cece63e7e"},
+    {file = "pydantic_core-2.6.3-cp310-none-win32.whl", hash = "sha256:04fe5c0a43dec39aedba0ec9579001061d4653a9b53a1366b113aca4a3c05ca7"},
+    {file = "pydantic_core-2.6.3-cp310-none-win_amd64.whl", hash = "sha256:6bf7d610ac8f0065a286002a23bcce241ea8248c71988bda538edcc90e0c39ad"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:6bcc1ad776fffe25ea5c187a028991c031a00ff92d012ca1cc4714087e575973"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:df14f6332834444b4a37685810216cc8fe1fe91f447332cd56294c984ecbff1c"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0b7486d85293f7f0bbc39b34e1d8aa26210b450bbd3d245ec3d732864009819"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a892b5b1871b301ce20d40b037ffbe33d1407a39639c2b05356acfef5536d26a"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:883daa467865e5766931e07eb20f3e8152324f0adf52658f4d302242c12e2c32"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4eb77df2964b64ba190eee00b2312a1fd7a862af8918ec70fc2d6308f76ac64"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ce8c84051fa292a5dc54018a40e2a1926fd17980a9422c973e3ebea017aa8da"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:22134a4453bd59b7d1e895c455fe277af9d9d9fbbcb9dc3f4a97b8693e7e2c9b"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:02e1c385095efbd997311d85c6021d32369675c09bcbfff3b69d84e59dc103f6"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d79f1f2f7ebdb9b741296b69049ff44aedd95976bfee38eb4848820628a99b50"},
+    {file = "pydantic_core-2.6.3-cp311-none-win32.whl", hash = "sha256:430ddd965ffd068dd70ef4e4d74f2c489c3a313adc28e829dd7262cc0d2dd1e8"},
+    {file = "pydantic_core-2.6.3-cp311-none-win_amd64.whl", hash = "sha256:84f8bb34fe76c68c9d96b77c60cef093f5e660ef8e43a6cbfcd991017d375950"},
+    {file = "pydantic_core-2.6.3-cp311-none-win_arm64.whl", hash = "sha256:5a2a3c9ef904dcdadb550eedf3291ec3f229431b0084666e2c2aa8ff99a103a2"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:8421cf496e746cf8d6b677502ed9a0d1e4e956586cd8b221e1312e0841c002d5"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bb128c30cf1df0ab78166ded1ecf876620fb9aac84d2413e8ea1594b588c735d"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37a822f630712817b6ecc09ccc378192ef5ff12e2c9bae97eb5968a6cdf3b862"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:240a015102a0c0cc8114f1cba6444499a8a4d0333e178bc504a5c2196defd456"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f90e5e3afb11268628c89f378f7a1ea3f2fe502a28af4192e30a6cdea1e7d5e"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:340e96c08de1069f3d022a85c2a8c63529fd88709468373b418f4cf2c949fb0e"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1480fa4682e8202b560dcdc9eeec1005f62a15742b813c88cdc01d44e85308e5"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f14546403c2a1d11a130b537dda28f07eb6c1805a43dae4617448074fd49c282"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:a87c54e72aa2ef30189dc74427421e074ab4561cf2bf314589f6af5b37f45e6d"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f93255b3e4d64785554e544c1c76cd32f4a354fa79e2eeca5d16ac2e7fdd57aa"},
+    {file = "pydantic_core-2.6.3-cp312-none-win32.whl", hash = "sha256:f70dc00a91311a1aea124e5f64569ea44c011b58433981313202c46bccbec0e1"},
+    {file = "pydantic_core-2.6.3-cp312-none-win_amd64.whl", hash = "sha256:23470a23614c701b37252618e7851e595060a96a23016f9a084f3f92f5ed5881"},
+    {file = "pydantic_core-2.6.3-cp312-none-win_arm64.whl", hash = "sha256:1ac1750df1b4339b543531ce793b8fd5c16660a95d13aecaab26b44ce11775e9"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:a53e3195f134bde03620d87a7e2b2f2046e0e5a8195e66d0f244d6d5b2f6d31b"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:f2969e8f72c6236c51f91fbb79c33821d12a811e2a94b7aa59c65f8dbdfad34a"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:672174480a85386dd2e681cadd7d951471ad0bb028ed744c895f11f9d51b9ebe"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:002d0ea50e17ed982c2d65b480bd975fc41086a5a2f9c924ef8fc54419d1dea3"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ccc13afee44b9006a73d2046068d4df96dc5b333bf3509d9a06d1b42db6d8bf"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:439a0de139556745ae53f9cc9668c6c2053444af940d3ef3ecad95b079bc9987"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d63b7545d489422d417a0cae6f9898618669608750fc5e62156957e609e728a5"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b44c42edc07a50a081672e25dfe6022554b47f91e793066a7b601ca290f71e42"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:1c721bfc575d57305dd922e6a40a8fe3f762905851d694245807a351ad255c58"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5e4a2cf8c4543f37f5dc881de6c190de08096c53986381daebb56a355be5dfe6"},
+    {file = "pydantic_core-2.6.3-cp37-none-win32.whl", hash = "sha256:d9b4916b21931b08096efed090327f8fe78e09ae8f5ad44e07f5c72a7eedb51b"},
+    {file = "pydantic_core-2.6.3-cp37-none-win_amd64.whl", hash = "sha256:a8acc9dedd304da161eb071cc7ff1326aa5b66aadec9622b2574ad3ffe225525"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:5e9c068f36b9f396399d43bfb6defd4cc99c36215f6ff33ac8b9c14ba15bdf6b"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e61eae9b31799c32c5f9b7be906be3380e699e74b2db26c227c50a5fc7988698"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85463560c67fc65cd86153a4975d0b720b6d7725cf7ee0b2d291288433fc21b"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9616567800bdc83ce136e5847d41008a1d602213d024207b0ff6cab6753fe645"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e9b65a55bbabda7fccd3500192a79f6e474d8d36e78d1685496aad5f9dbd92c"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f468d520f47807d1eb5d27648393519655eadc578d5dd862d06873cce04c4d1b"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9680dd23055dd874173a3a63a44e7f5a13885a4cfd7e84814be71be24fba83db"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a718d56c4d55efcfc63f680f207c9f19c8376e5a8a67773535e6f7e80e93170"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8ecbac050856eb6c3046dea655b39216597e373aa8e50e134c0e202f9c47efec"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:788be9844a6e5c4612b74512a76b2153f1877cd845410d756841f6c3420230eb"},
+    {file = "pydantic_core-2.6.3-cp38-none-win32.whl", hash = "sha256:07a1aec07333bf5adebd8264047d3dc518563d92aca6f2f5b36f505132399efc"},
+    {file = "pydantic_core-2.6.3-cp38-none-win_amd64.whl", hash = "sha256:621afe25cc2b3c4ba05fff53525156d5100eb35c6e5a7cf31d66cc9e1963e378"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:813aab5bfb19c98ae370952b6f7190f1e28e565909bfc219a0909db168783465"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:50555ba3cb58f9861b7a48c493636b996a617db1a72c18da4d7f16d7b1b9952b"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19e20f8baedd7d987bd3f8005c146e6bcbda7cdeefc36fad50c66adb2dd2da48"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b0a5d7edb76c1c57b95df719af703e796fc8e796447a1da939f97bfa8a918d60"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f06e21ad0b504658a3a9edd3d8530e8cea5723f6ea5d280e8db8efc625b47e49"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea053cefa008fda40f92aab937fb9f183cf8752e41dbc7bc68917884454c6362"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:171a4718860790f66d6c2eda1d95dd1edf64f864d2e9f9115840840cf5b5713f"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ed7ceca6aba5331ece96c0e328cd52f0dcf942b8895a1ed2642de50800b79d3"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:acafc4368b289a9f291e204d2c4c75908557d4f36bd3ae937914d4529bf62a76"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1aa712ba150d5105814e53cb141412217146fedc22621e9acff9236d77d2a5ef"},
+    {file = "pydantic_core-2.6.3-cp39-none-win32.whl", hash = "sha256:44b4f937b992394a2e81a5c5ce716f3dcc1237281e81b80c748b2da6dd5cf29a"},
+    {file = "pydantic_core-2.6.3-cp39-none-win_amd64.whl", hash = "sha256:9b33bf9658cb29ac1a517c11e865112316d09687d767d7a0e4a63d5c640d1b17"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:d7050899026e708fb185e174c63ebc2c4ee7a0c17b0a96ebc50e1f76a231c057"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:99faba727727b2e59129c59542284efebbddade4f0ae6a29c8b8d3e1f437beb7"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fa159b902d22b283b680ef52b532b29554ea2a7fc39bf354064751369e9dbd7"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:046af9cfb5384f3684eeb3f58a48698ddab8dd870b4b3f67f825353a14441418"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:930bfe73e665ebce3f0da2c6d64455098aaa67e1a00323c74dc752627879fc67"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:85cc4d105747d2aa3c5cf3e37dac50141bff779545ba59a095f4a96b0a460e70"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b25afe9d5c4f60dcbbe2b277a79be114e2e65a16598db8abee2a2dcde24f162b"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e49ce7dc9f925e1fb010fc3d555250139df61fa6e5a0a95ce356329602c11ea9"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:2dd50d6a1aef0426a1d0199190c6c43ec89812b1f409e7fe44cb0fbf6dfa733c"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6595b0d8c8711e8e1dc389d52648b923b809f68ac1c6f0baa525c6440aa0daa"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ef724a059396751aef71e847178d66ad7fc3fc969a1a40c29f5aac1aa5f8784"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3c8945a105f1589ce8a693753b908815e0748f6279959a4530f6742e1994dcb6"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c8c6660089a25d45333cb9db56bb9e347241a6d7509838dbbd1931d0e19dbc7f"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:692b4ff5c4e828a38716cfa92667661a39886e71136c97b7dac26edef18767f7"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:f1a5d8f18877474c80b7711d870db0eeef9442691fcdb00adabfc97e183ee0b0"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3796a6152c545339d3b1652183e786df648ecdf7c4f9347e1d30e6750907f5bb"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:b962700962f6e7a6bd77e5f37320cabac24b4c0f76afeac05e9f93cf0c620014"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56ea80269077003eaa59723bac1d8bacd2cd15ae30456f2890811efc1e3d4413"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c0ebbebae71ed1e385f7dfd9b74c1cff09fed24a6df43d326dd7f12339ec34"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:252851b38bad3bfda47b104ffd077d4f9604a10cb06fe09d020016a25107bf98"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:6656a0ae383d8cd7cc94e91de4e526407b3726049ce8d7939049cbfa426518c8"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:d9140ded382a5b04a1c030b593ed9bf3088243a0a8b7fa9f071a5736498c5483"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d38bbcef58220f9c81e42c255ef0bf99735d8f11edef69ab0b499da77105158a"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:c9d469204abcca28926cbc28ce98f28e50e488767b084fb3fbdf21af11d3de26"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:48c1ed8b02ffea4d5c9c220eda27af02b8149fe58526359b3c07eb391cb353a2"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b2b1bfed698fa410ab81982f681f5b1996d3d994ae8073286515ac4d165c2e7"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf9d42a71a4d7a7c1f14f629e5c30eac451a6fc81827d2beefd57d014c006c4a"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4292ca56751aebbe63a84bbfc3b5717abb09b14d4b4442cc43fd7c49a1529efd"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:7dc2ce039c7290b4ef64334ec7e6ca6494de6eecc81e21cb4f73b9b39991408c"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:615a31b1629e12445c0e9fc8339b41aaa6cc60bd53bf802d5fe3d2c0cda2ae8d"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1fa1f6312fb84e8c281f32b39affe81984ccd484da6e9d65b3d18c202c666149"},
+    {file = "pydantic_core-2.6.3.tar.gz", hash = "sha256:1508f37ba9e3ddc0189e6ff4e2228bd2d3c3a4641cbe8c07177162f76ed696c7"},
 ]
 
 [package.dependencies]
@@ -1119,13 +1155,13 @@ certifi = "*"
 
 [[package]]
 name = "pytest"
-version = "7.4.0"
+version = "7.4.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
-    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+    {file = "pytest-7.4.1-py3-none-any.whl", hash = "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"},
+    {file = "pytest-7.4.1.tar.gz", hash = "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab"},
 ]
 
 [package.dependencies]
@@ -1155,13 +1191,13 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2023.3"
+version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
-    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
 ]
 
 [[package]]
@@ -1236,20 +1272,31 @@ files = [
 ]
 
 [[package]]
+name = "semver"
+version = "3.0.1"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.1-py3-none-any.whl", hash = "sha256:2a23844ba1647362c7490fe3995a86e097bb590d16f0f32dfc383008f19e4cdf"},
+    {file = "semver-3.0.1.tar.gz", hash = "sha256:9ec78c5447883c67b97f98c3b6212796708191d22e4ad30f4570f840171cbce1"},
+]
+
+[[package]]
 name = "setuptools"
-version = "68.1.2"
+version = "68.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.1.2-py3-none-any.whl", hash = "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"},
-    {file = "setuptools-68.1.2.tar.gz", hash = "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d"},
+    {file = "setuptools-68.2.0-py3-none-any.whl", hash = "sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8"},
+    {file = "setuptools-68.2.0.tar.gz", hash = "sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5,<=7.1.2)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "shapely"
@@ -1425,4 +1472,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "25bd05a4e9f15d882c1cb9ee627889a5c3aceeb099411d6a534ff5439449d692"
+content-hash = "c41554f076cfe5d45f67fd2ba5c5aff5974fb15ba918a0a5228a7fe647d78976"

--- a/poetry.lock
+++ b/poetry.lock
@@ -321,6 +321,73 @@ test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
 test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
 
 [[package]]
+name = "coverage"
+version = "7.3.1"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd0f7429ecfd1ff597389907045ff209c8fdb5b013d38cfa7c60728cb484b6e3"},
+    {file = "coverage-7.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:966f10df9b2b2115da87f50f6a248e313c72a668248be1b9060ce935c871f276"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0575c37e207bb9b98b6cf72fdaaa18ac909fb3d153083400c2d48e2e6d28bd8e"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:245c5a99254e83875c7fed8b8b2536f040997a9b76ac4c1da5bff398c06e860f"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c96dd7798d83b960afc6c1feb9e5af537fc4908852ef025600374ff1a017392"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:de30c1aa80f30af0f6b2058a91505ea6e36d6535d437520067f525f7df123887"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:50dd1e2dd13dbbd856ffef69196781edff26c800a74f070d3b3e3389cab2600d"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9c0c19f70d30219113b18fe07e372b244fb2a773d4afde29d5a2f7930765136"},
+    {file = "coverage-7.3.1-cp310-cp310-win32.whl", hash = "sha256:770f143980cc16eb601ccfd571846e89a5fe4c03b4193f2e485268f224ab602f"},
+    {file = "coverage-7.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:cdd088c00c39a27cfa5329349cc763a48761fdc785879220d54eb785c8a38520"},
+    {file = "coverage-7.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74bb470399dc1989b535cb41f5ca7ab2af561e40def22d7e188e0a445e7639e3"},
+    {file = "coverage-7.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:025ded371f1ca280c035d91b43252adbb04d2aea4c7105252d3cbc227f03b375"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6191b3a6ad3e09b6cfd75b45c6aeeffe7e3b0ad46b268345d159b8df8d835f9"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb0b188f30e41ddd659a529e385470aa6782f3b412f860ce22b2491c89b8593"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c8f0df9dfd8ff745bccff75867d63ef336e57cc22b2908ee725cc552689ec8"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7eb3cd48d54b9bd0e73026dedce44773214064be93611deab0b6a43158c3d5a0"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ac3c5b7e75acac31e490b7851595212ed951889918d398b7afa12736c85e13ce"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5b4ee7080878077af0afa7238df1b967f00dc10763f6e1b66f5cced4abebb0a3"},
+    {file = "coverage-7.3.1-cp311-cp311-win32.whl", hash = "sha256:229c0dd2ccf956bf5aeede7e3131ca48b65beacde2029f0361b54bf93d36f45a"},
+    {file = "coverage-7.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6f55d38818ca9596dc9019eae19a47410d5322408140d9a0076001a3dcb938c"},
+    {file = "coverage-7.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5289490dd1c3bb86de4730a92261ae66ea8d44b79ed3cc26464f4c2cde581fbc"},
+    {file = "coverage-7.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ca833941ec701fda15414be400c3259479bfde7ae6d806b69e63b3dc423b1832"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd694e19c031733e446c8024dedd12a00cda87e1c10bd7b8539a87963685e969"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aab8e9464c00da5cb9c536150b7fbcd8850d376d1151741dd0d16dfe1ba4fd26"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87d38444efffd5b056fcc026c1e8d862191881143c3aa80bb11fcf9dca9ae204"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8a07b692129b8a14ad7a37941a3029c291254feb7a4237f245cfae2de78de037"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:2829c65c8faaf55b868ed7af3c7477b76b1c6ebeee99a28f59a2cb5907a45760"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f111a7d85658ea52ffad7084088277135ec5f368457275fc57f11cebb15607f"},
+    {file = "coverage-7.3.1-cp312-cp312-win32.whl", hash = "sha256:c397c70cd20f6df7d2a52283857af622d5f23300c4ca8e5bd8c7a543825baa5a"},
+    {file = "coverage-7.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:5ae4c6da8b3d123500f9525b50bf0168023313963e0e2e814badf9000dd6ef92"},
+    {file = "coverage-7.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ca70466ca3a17460e8fc9cea7123c8cbef5ada4be3140a1ef8f7b63f2f37108f"},
+    {file = "coverage-7.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f2781fd3cabc28278dc982a352f50c81c09a1a500cc2086dc4249853ea96b981"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6407424621f40205bbe6325686417e5e552f6b2dba3535dd1f90afc88a61d465"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:04312b036580ec505f2b77cbbdfb15137d5efdfade09156961f5277149f5e344"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9ad38204887349853d7c313f53a7b1c210ce138c73859e925bc4e5d8fc18e7"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:53669b79f3d599da95a0afbef039ac0fadbb236532feb042c534fbb81b1a4e40"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:614f1f98b84eb256e4f35e726bfe5ca82349f8dfa576faabf8a49ca09e630086"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f1a317fdf5c122ad642db8a97964733ab7c3cf6009e1a8ae8821089993f175ff"},
+    {file = "coverage-7.3.1-cp38-cp38-win32.whl", hash = "sha256:defbbb51121189722420a208957e26e49809feafca6afeef325df66c39c4fdb3"},
+    {file = "coverage-7.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:f4f456590eefb6e1b3c9ea6328c1e9fa0f1006e7481179d749b3376fc793478e"},
+    {file = "coverage-7.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f12d8b11a54f32688b165fd1a788c408f927b0960984b899be7e4c190ae758f1"},
+    {file = "coverage-7.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f09195dda68d94a53123883de75bb97b0e35f5f6f9f3aa5bf6e496da718f0cb6"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6601a60318f9c3945be6ea0f2a80571f4299b6801716f8a6e4846892737ebe4"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07d156269718670d00a3b06db2288b48527fc5f36859425ff7cec07c6b367745"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:636a8ac0b044cfeccae76a36f3b18264edcc810a76a49884b96dd744613ec0b7"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5d991e13ad2ed3aced177f524e4d670f304c8233edad3210e02c465351f785a0"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:586649ada7cf139445da386ab6f8ef00e6172f11a939fc3b2b7e7c9082052fa0"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4aba512a15a3e1e4fdbfed2f5392ec221434a614cc68100ca99dcad7af29f3f8"},
+    {file = "coverage-7.3.1-cp39-cp39-win32.whl", hash = "sha256:6bc6f3f4692d806831c136c5acad5ccedd0262aa44c087c46b7101c77e139140"},
+    {file = "coverage-7.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:553d7094cb27db58ea91332e8b5681bac107e7242c23f7629ab1316ee73c4981"},
+    {file = "coverage-7.3.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:220eb51f5fb38dfdb7e5d54284ca4d0cd70ddac047d750111a68ab1798945194"},
+    {file = "coverage-7.3.1.tar.gz", hash = "sha256:6cb7fe1581deb67b782c153136541e20901aa312ceedaf1467dcb35255787952"},
+]
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cycler"
 version = "0.11.0"
 description = "Composable style cycles"
@@ -1279,6 +1346,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "4.1.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+]
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1607,4 +1692,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a22282e0f7e4c4d841753218efec819cf6b6eb9ee550310b354955e33976c774"
+content-hash = "ddf28654b4f1a621c09b75b4d686f9ba2fb91bf1fa89398fdfb507e8445e3160"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1433,6 +1433,28 @@ doc = ["cairosvg (>=2.5.2,<2.6.0)", "mdx-include (>=1.4.1,<1.5.0)", "mkdocs (>=1
 test = ["black (>=22.3.0,<22.4.0)", "coverage (>=6.0.0,<6.1.0)", "docstring_parser (>=0.15,<1.0)", "isort (>=5.10.1,<5.11.0)", "mypy (>=0.950,<1.0)", "pytest (>=7.1.2,<7.2.0)", "pytest-cov (>=3.0.0,<3.1.0)", "pytest-forked (>=1.4.0,<1.5.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=3.0.2,<3.1.0)"]
 
 [[package]]
+name = "types-pycocotools"
+version = "2.0.0.4"
+description = "Typing stubs for pycocotools"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-pycocotools-2.0.0.4.tar.gz", hash = "sha256:5eb30920a6d2ae2549167422dcf39d4005d525f03902c0d0e99b4ea6d1c38f6e"},
+    {file = "types_pycocotools-2.0.0.4-py3-none-any.whl", hash = "sha256:8ec8169d0da5280624cf4e720dd20f703bc0b65e2a69abb73f783c97b6a4b93e"},
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.66.0.2"
+description = "Typing stubs for tqdm"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-tqdm-4.66.0.2.tar.gz", hash = "sha256:9553a5e44c1d485fce19f505b8bd65c0c3e87e870678d1f2ed764ae59a55d45f"},
+    {file = "types_tqdm-4.66.0.2-py3-none-any.whl", hash = "sha256:13dddd38908834abdf0acdc2b70cab7ac4bcc5ad7356ced450471662e58a0ffc"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1472,4 +1494,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c41554f076cfe5d45f67fd2ba5c5aff5974fb15ba918a0a5228a7fe647d78976"
+content-hash = "3e3e040f9a53f3cd9e98eaa5f31288a6ef6a485363ee523e3b7cbcfa3602810d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ ruff = "^0.0.285"
 types-pycocotools = "^2.0.0.4"
 types-tqdm = "^4.66.0.2"
 docformatter = {extras = ["tomli"], version = "^1.7.5"}
+pytest-cov = "^4.1.0"
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ black = "^23.7.0"
 ruff = "^0.0.285"
 types-pycocotools = "^2.0.0.4"
 types-tqdm = "^4.66.0.2"
+docformatter = {extras = ["tomli"], version = "^1.7.5"}
 
 [[tool.mypy.overrides]]
 module = [
@@ -39,6 +40,15 @@ module = [
     "shapely.*"
 ]
 ignore_missing_imports = true
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.per-file-ignores]
+"geococo/__init__.py" = ["F401"]
+
+[tool.docformatter]
+black = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geococo"
-version = "0.1.2"
+version = "0.2.0"
 description = "Converts GIS annotations to Microsoft's Common Objects In Context (COCO) dataset format"
 authors = ["Jasper <j.siebring92@gmail.com>"]
 readme = "README.md"
@@ -22,6 +22,7 @@ tqdm = "^4.66.1"
 typing-extensions = "^4.7.1"
 typer-cloup = "^0.11.0"
 docstring-parser = "^0.15"
+semver = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,16 @@ pytest = "^7.4.0"
 mypy = "^1.5.1"
 black = "^23.7.0"
 ruff = "^0.0.285"
+types-pycocotools = "^2.0.0.4"
+types-tqdm = "^4.66.0.2"
+
+[[tool.mypy.overrides]]
+module = [
+    "rasterio.*",
+    "geopandas",
+    "shapely.*"
+]
+ignore_missing_imports = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,13 +14,13 @@ from shapely.geometry import Point
 def set_seed() -> None:
     np.random.seed(0)
 
+
 @pytest.fixture
 def raster_factory(
     tmp_path: pathlib.Path,
 ) -> Callable[[int, int, int, str, CRS, int], pathlib.Path]:
-    """
-    Pytest "factory" fixture that returns a method that can generate a raster file of a
-    given specification.
+    """Pytest "factory" fixture that returns a method that can generate a raster file of
+    a given specification.
 
     :param tmp_path: pytest fixture that gives a temporary directory
     :return: method for generating raster files
@@ -34,24 +34,24 @@ def raster_factory(
         crs: CRS = CRS.from_epsg(3857),
         nodata: int = 0,
     ) -> pathlib.Path:
-        """
-        Generates a random raster file of (3, width, height).astype(dtype) at 0,0 of a given CRS
-        and returns a tempdir path to this file. The units of height/weight is determined by the
-        CRS (i.e. meters for projected, degrees for geographic).
+        """Generates a random raster file of (3, width, height).astype(dtype) at 0,0 of
+        a given CRS and returns a tempdir path to this file. The units of height/weight
+        is determined by the CRS (i.e. meters for projected, degrees for geographic).
 
         :param width: number of pixels in x axis
         :param height: number of pixels in y axis
         :param count: number of bands in generated raster
         :param dtype: dtype for the generated raster
-        :param crs: coordinate reference system to use (also determines the pixel_size units)
+        :param crs: coordinate reference system to use (also determines the pixel_size
+            units)
         :param nodata: what value to use as NULL value in generated raster
         :return: tmp_path to generated raster
         """
 
         raster_path = tmp_path / f"{uuid.uuid1()}.tif"
-        transform = from_origin(0, 0, 1, 1) #i.e. top left with pixel size 1
+        transform = from_origin(0, 0, 1, 1)  # i.e. top left with pixel size 1
         data = np.multiply(np.random.rand(count, width, height), 256).astype(dtype)
-        
+
         profile = {
             "driver": "GTiff",
             "height": height,
@@ -69,46 +69,60 @@ def raster_factory(
 
     return _generate_raster
 
+
 @pytest.fixture(scope="session")
 def overlapping_labels() -> gpd.GeoDataFrame:
-    """ Pytest fixture that returns hardcoded labels as a geodataframe for testing purposes """
+    """Pytest fixture that returns hardcoded labels as a geodataframe for testing
+    purposes."""
 
     crs = CRS.from_epsg(3857)
     classes = [1, 2, 2, 5, 5]
-    points = [Point(10, -10),  Point(30, -30), Point(50, -50), Point(70, -70), Point(90, -90)]
+    points = [
+        Point(10, -10),
+        Point(30, -30),
+        Point(50, -50),
+        Point(70, -70),
+        Point(90, -90),
+    ]
     buffers = [1, 2, 3, 4, 1]
     polygons = [p.buffer(distance=buffers[i]) for i, p in enumerate(points)]
-    
+
     labels = gpd.GeoDataFrame(
-         geometry=polygons,
-         data={"category_id": classes},
-         crs=crs
-         ) # type: ignore
+        geometry=polygons, data={"category_id": classes}, crs=crs
+    )  # type: ignore
     return labels
+
 
 @pytest.fixture(scope="session")
 def nonoverlapping_labels() -> gpd.GeoDataFrame:
-    """ Pytest fixture that returns hardcoded labels as a geodataframe for testing purposes """
+    """Pytest fixture that returns hardcoded labels as a geodataframe for testing
+    purposes."""
 
     crs = CRS.from_epsg(3857)
     classes = [1, 2, 2, 5, 5]
-    points = [Point(510, -510),  Point(530, -530), Point(550, -550), Point(570, -570), Point(590, -590)]
+    points = [
+        Point(510, -510),
+        Point(530, -530),
+        Point(550, -550),
+        Point(570, -570),
+        Point(590, -590),
+    ]
     buffers = [1, 2, 3, 4, 1]
     polygons = [p.buffer(distance=buffers[i]) for i, p in enumerate(points)]
-    
+
     labels = gpd.GeoDataFrame(
-         geometry=polygons,
-         data={"category_id": classes},
-         crs=crs
-         ) # type: ignore
+        geometry=polygons, data={"category_id": classes}, crs=crs
+    )  # type: ignore
     return labels
 
+
 @pytest.fixture
-def test_raster(raster_factory: Callable[[int, int, int, str, CRS, int], pathlib.Path]) -> pathlib.Path:
-    """
-    Pytest fixture that generates a geotiff with given specifications, saves it to a temporary 
-    directory and returns its path.
-    
+def test_raster(
+    raster_factory: Callable[[int, int, int, str, CRS, int], pathlib.Path]
+) -> pathlib.Path:
+    """Pytest fixture that generates a geotiff with given specifications, saves it to a
+    temporary directory and returns its path.
+
     :param raster_factory: fixture that generate a raster file of given specification
     :return: path to generated geotiff
     """

--- a/tests/test_coco_manager.py
+++ b/tests/test_coco_manager.py
@@ -7,71 +7,96 @@ from geococo.coco_processing import labels_to_dataset
 from geococo.coco_models import Info, CocoDataset
 from geococo.coco_manager import load_dataset, create_dataset, save_dataset
 
-def test_load_dataset_full(tmp_path: pathlib.Path, test_raster: pathlib.Path, overlapping_labels: gpd.GeoDataFrame) -> None:
+
+def test_load_dataset_full(
+    tmp_path: pathlib.Path,
+    test_raster: pathlib.Path,
+    overlapping_labels: gpd.GeoDataFrame,
+) -> None:
     json_path = tmp_path / "dataset.json"
 
     with rasterio.open(test_raster) as raster_source:
         # Creating empty CocoDataset as input for labels_to_dataset
-        info = Info(version = "0.0.1", date_created=datetime.now())
+        info = Info(version="0.0.1", date_created=datetime.now())
         dataset = CocoDataset(info=info)
         dataset = labels_to_dataset(
-            dataset = dataset,
-            images_dir = tmp_path,
-            src = raster_source,
-            labels = overlapping_labels,
-            window_bounds = [(256, 256)]
-            )
-        
+            dataset=dataset,
+            images_dir=tmp_path,
+            src=raster_source,
+            labels=overlapping_labels,
+            window_bounds=[(256, 256)],
+        )
+
     json_data = dataset.model_dump_json()
-    with open(json_path, 'w') as dst:
+    with open(json_path, "w") as dst:
         dst.write(json_data)
 
     loaded_dataset = load_dataset(json_path=json_path)
     assert loaded_dataset == dataset
+
 
 def test_load_dataset_empty(tmp_path: pathlib.Path) -> None:
     json_path = tmp_path / "dataset.json"
-    info = Info(version = "0.0.1", date_created=datetime.now())
+    info = Info(version="0.0.1", date_created=datetime.now())
     dataset = CocoDataset(info=info)
 
     json_data = dataset.model_dump_json()
-    with open(json_path, 'w') as dst:
+    with open(json_path, "w") as dst:
         dst.write(json_data)
 
     loaded_dataset = load_dataset(json_path=json_path)
     assert loaded_dataset == dataset
 
-@pytest.mark.parametrize("contributor, version, description, date_created", [("User", "0.1.0", "Test", datetime.now()), ("", "", "", datetime.now()), (None, None, None, datetime.now())])
+
+@pytest.mark.parametrize(
+    "contributor, version, description, date_created",
+    [
+        ("User", "0.1.0", "Test", datetime.now()),
+        ("", "", "", datetime.now()),
+        (None, None, None, datetime.now()),
+    ],
+)
 def test_create_dataset(contributor, version, description, date_created) -> None:
     # pretty much already tested by tests/test_coco_models.py
-    dataset = create_dataset(contributor=contributor, version=version, date_created=date_created, description=description)    
+    dataset = create_dataset(
+        contributor=contributor,
+        version=version,
+        date_created=date_created,
+        description=description,
+    )
     assert isinstance(dataset, CocoDataset)
     assert dataset.next_annotation_id == 1
     assert dataset.next_image_id == 1
 
+
 def test_save_dataset_empty(tmp_path: pathlib.Path) -> None:
     json_path = tmp_path / "dataset.json"
-    info = Info(version = "0.0.1", date_created=datetime.now())
+    info = Info(version="0.0.1", date_created=datetime.now())
     dataset = CocoDataset(info=info)
     save_dataset(dataset=dataset, json_path=json_path)
     loaded_dataset = load_dataset(json_path=json_path)
     assert loaded_dataset == dataset
 
-def test_save_dataset_full(tmp_path: pathlib.Path, test_raster: pathlib.Path, overlapping_labels: gpd.GeoDataFrame) -> None:
+
+def test_save_dataset_full(
+    tmp_path: pathlib.Path,
+    test_raster: pathlib.Path,
+    overlapping_labels: gpd.GeoDataFrame,
+) -> None:
     json_path = tmp_path / "dataset.json"
 
     with rasterio.open(test_raster) as raster_source:
         # Creating empty CocoDataset as input for labels_to_dataset
-        info = Info(version = "0.0.1", date_created=datetime.now())
+        info = Info(version="0.0.1", date_created=datetime.now())
         dataset = CocoDataset(info=info)
         dataset = labels_to_dataset(
-            dataset = dataset,
-            images_dir = tmp_path,
-            src = raster_source,
-            labels = overlapping_labels,
-            window_bounds = [(256, 256)]
-            )
-        
+            dataset=dataset,
+            images_dir=tmp_path,
+            src=raster_source,
+            labels=overlapping_labels,
+            window_bounds=[(256, 256)],
+        )
+
     save_dataset(dataset=dataset, json_path=json_path)
     loaded_dataset = load_dataset(json_path=json_path)
     assert loaded_dataset == dataset

--- a/tests/test_coco_manager.py
+++ b/tests/test_coco_manager.py
@@ -52,8 +52,8 @@ def test_load_dataset_empty(tmp_path: pathlib.Path) -> None:
     "contributor, version, description, date_created",
     [
         ("User", "0.1.0", "Test", datetime.now()),
-        ("", "", "", datetime.now()),
-        (None, None, None, datetime.now()),
+        ("", "123.123.123", "", datetime.now()),
+        (None, "0.0.0", None, datetime.now()),
     ],
 )
 def test_create_dataset(contributor, version, description, date_created) -> None:

--- a/tests/test_coco_models.py
+++ b/tests/test_coco_models.py
@@ -60,8 +60,7 @@ def test_dataset_add_images():
     dataset = CocoDataset(info=Info())
     assert dataset.next_annotation_id == 1
     assert dataset.next_image_id == 1
-    assert dataset.next_source_id == 1
-
+    
     n_images = np.random.randint(2, 10)
 
     for _ in range(n_images):
@@ -76,7 +75,6 @@ def test_dataset_add_images():
 
     assert n_images == dataset.next_image_id - 1
     assert n_images == len(dataset.images)
-
 
 def test_info():
     """Simple instance test."""
@@ -129,4 +127,20 @@ def test_segmentation():
 def test_source():
     """Simple instance test."""
 
-    Source(file_name=pathlib.Path(), source_id=1)
+    Source(file_name=pathlib.Path(), id=1)
+
+
+def test_dataset_add_sources():
+    """Checks proper incrementation of source_id"""
+
+    # Bit different from the other ids since we check for duplication 
+    # and only increment if new
+    dataset = CocoDataset(info=Info())
+    assert dataset.next_source_id == 0
+    dataset.add_source(source_path=pathlib.Path("a"))
+    assert dataset.next_source_id == 1
+    # duplicates are still being added, this is wrong and should be fixed
+    dataset.add_source(source_path=pathlib.Path("a"))
+    assert dataset.next_source_id == 1
+    dataset.add_source(source_path=pathlib.Path("b"))
+    assert dataset.next_source_id == 2

--- a/tests/test_coco_models.py
+++ b/tests/test_coco_models.py
@@ -81,7 +81,6 @@ def test_info():
 
     Info(
         year=None,
-        version=None,
         description=None,
         contributor=None,
         date_created=datetime.now(),
@@ -139,8 +138,26 @@ def test_dataset_add_sources():
     assert dataset.next_source_id == 0
     dataset.add_source(source_path=pathlib.Path("a"))
     assert dataset.next_source_id == 1
-    # duplicates are still being added, this is wrong and should be fixed
     dataset.add_source(source_path=pathlib.Path("a"))
     assert dataset.next_source_id == 1
     dataset.add_source(source_path=pathlib.Path("b"))
     assert dataset.next_source_id == 2
+
+
+def test_dataset_versions(tmp_path: pathlib.Path):
+    """Checks proper incrementation of dataset versions"""
+
+    dataset = CocoDataset(info=Info())
+    assert dataset.info.version == "0.0.0"
+    
+    # minor bump if same output_dir but different raster_source
+    dataset.add_source(source_path=pathlib.Path("a"))
+    assert dataset.info.version == "0.1.0"
+
+    # patch bump: if same output_dir and same raster_source
+    dataset.add_source(source_path=pathlib.Path("a"))
+    assert dataset.info.version == "0.1.1"
+
+    # major bump: if new output_dir
+    dataset.verify_new_output_dir(images_dir=pathlib.Path("b"))
+    assert dataset.info.version == "1.0.0"

--- a/tests/test_coco_models.py
+++ b/tests/test_coco_models.py
@@ -2,11 +2,15 @@ import os
 import numpy as np
 import pathlib
 from datetime import datetime
-from geococo.coco_models import CocoDataset, Info, Image, Annotation, Category, RleDict, Source
-
-"""
-Preface: we're mainly testing the logic inside the pydantic models, not the models/fields themselves (that would be a bit redundant)
-"""
+from geococo.coco_models import (
+    CocoDataset,
+    Info,
+    Image,
+    Annotation,
+    Category,
+    RleDict,
+    Source,
+)
 
 
 def test_dataset():
@@ -24,13 +28,15 @@ def test_dataset():
 
 
 def test_dataset_add_annotations():
-    """Checks annotation_id increment"""
+    """Checks annotation_id increment."""
 
     dataset = CocoDataset(info=Info())
     assert dataset.next_annotation_id == 1
     assert dataset.next_image_id == 1
     n_annotations = np.random.randint(2, 10)
-    segmentation = RleDict(size= [256, 256], counts=  os.urandom(np.random.randint(1, 100)))
+    segmentation = RleDict(
+        size=[256, 256], counts=os.urandom(np.random.randint(1, 100))
+    )
 
     for _ in range(n_annotations):
         ann = Annotation(
@@ -49,7 +55,7 @@ def test_dataset_add_annotations():
 
 
 def test_dataset_add_images():
-    """Checks image_id increment"""
+    """Checks image_id increment."""
 
     dataset = CocoDataset(info=Info())
     assert dataset.next_annotation_id == 1
@@ -64,7 +70,7 @@ def test_dataset_add_images():
             width=512,
             height=512,
             file_name=pathlib.Path("image.png"),
-            source_id=1
+            source_id=1,
         )
         dataset.add_image(image=img)
 
@@ -73,7 +79,7 @@ def test_dataset_add_images():
 
 
 def test_info():
-    """Simple instance test"""
+    """Simple instance test."""
 
     Info(
         year=None,
@@ -85,15 +91,17 @@ def test_info():
 
 
 def test_image():
-    """Simple instance test"""
+    """Simple instance test."""
 
     Image(id=1, width=512, height=512, file_name=pathlib.Path("image.png"), source_id=1)
 
 
 def test_annotation():
-    """Simple instance test"""
+    """Simple instance test."""
 
-    segmentation = RleDict(size= [256, 256], counts=  os.urandom(np.random.randint(1, 100)))
+    segmentation = RleDict(
+        size=[256, 256], counts=os.urandom(np.random.randint(1, 100))
+    )
 
     Annotation(
         id=1,
@@ -107,17 +115,18 @@ def test_annotation():
 
 
 def test_category():
-    """Simple instance test"""
+    """Simple instance test."""
 
     Category(id=1, name="", supercategory="")
 
+
 def test_segmentation():
-    """Simple instance test"""
-    
-    RleDict(size= [256, 256], counts=  os.urandom(np.random.randint(1, 100)))
+    """Simple instance test."""
+
+    RleDict(size=[256, 256], counts=os.urandom(np.random.randint(1, 100)))
 
 
 def test_source():
-    """Simple instance test"""
-    
+    """Simple instance test."""
+
     Source(file_name=pathlib.Path(), source_id=1)

--- a/tests/test_coco_models.py
+++ b/tests/test_coco_models.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pathlib
 from datetime import datetime
-from geococo.coco_models import CocoDataset, Info, Image, Annotation, Category, RleDict
+from geococo.coco_models import CocoDataset, Info, Image, Annotation, Category, RleDict, Source
 
 """
 Preface: we're mainly testing the logic inside the pydantic models, not the models/fields themselves (that would be a bit redundant)
@@ -54,6 +54,8 @@ def test_dataset_add_images():
     dataset = CocoDataset(info=Info())
     assert dataset.next_annotation_id == 1
     assert dataset.next_image_id == 1
+    assert dataset.next_source_id == 1
+
     n_images = np.random.randint(2, 10)
 
     for _ in range(n_images):
@@ -62,6 +64,7 @@ def test_dataset_add_images():
             width=512,
             height=512,
             file_name=pathlib.Path("image.png"),
+            source_id=1
         )
         dataset.add_image(image=img)
 
@@ -84,7 +87,7 @@ def test_info():
 def test_image():
     """Simple instance test"""
 
-    Image(id=1, width=512, height=512, file_name=pathlib.Path("image.png"))
+    Image(id=1, width=512, height=512, file_name=pathlib.Path("image.png"), source_id=1)
 
 
 def test_annotation():
@@ -112,3 +115,9 @@ def test_segmentation():
     """Simple instance test"""
     
     RleDict(size= [256, 256], counts=  os.urandom(np.random.randint(1, 100)))
+
+
+def test_source():
+    """Simple instance test"""
+    
+    Source(file_name=pathlib.Path(), source_id=1)

--- a/tests/test_coco_processing.py
+++ b/tests/test_coco_processing.py
@@ -3,72 +3,85 @@ import geopandas as gpd
 import rasterio
 import numpy as np
 from datetime import datetime
-from pyproj.crs.crs import CRS
 from geococo.coco_processing import labels_to_dataset
 from geococo.coco_models import CocoDataset, Info
 
-def test_labels_to_dataset_new_dataset(tmp_path: pathlib.Path, test_raster: pathlib.Path, overlapping_labels: gpd.GeoDataFrame) -> None:
+
+def test_labels_to_dataset_new_dataset(
+    tmp_path: pathlib.Path,
+    test_raster: pathlib.Path,
+    overlapping_labels: gpd.GeoDataFrame,
+) -> None:
     json_path = tmp_path / "dataset.json"
-    
+
     with rasterio.open(test_raster) as raster_source:
         # Creating empty CocoDataset as input for labels_to_dataset
-        info = Info(version = "0.0.1", date_created=datetime.now())
+        info = Info(version="0.0.1", date_created=datetime.now())
         dataset = CocoDataset(info=info)
         dataset = labels_to_dataset(
-            dataset = dataset,
-            images_dir = tmp_path,
-            src = raster_source,
-            labels = overlapping_labels,
-            window_bounds = [(256, 256)]
-            )
+            dataset=dataset,
+            images_dir=tmp_path,
+            src=raster_source,
+            labels=overlapping_labels,
+            window_bounds=[(256, 256)],
+        )
 
         # Checking if output has correct classes
         unique_ann_ids = np.unique([ann.category_id for ann in dataset.annotations])
-        assert np.all(np.isin(unique_ann_ids, overlapping_labels['category_id'].unique()))
-        
-        # Dumping to JSON    
+        assert np.all(
+            np.isin(unique_ann_ids, overlapping_labels["category_id"].unique())
+        )
+
+        # Dumping to JSON
         dst_json_data = dataset.model_dump_json()
-        with open(json_path, 'w') as dst_json_fp:
+        with open(json_path, "w") as dst_json_fp:
             dst_json_fp.write(dst_json_data)
 
         # Reading from JSON to verify correct encoding/decoding
         with open(json_path) as src_json_fp:
             src_json_data = src_json_fp.read()
-        
+
         # Reinstating CocoDataset from json and verifying if still identical
         reinstated_dataset = CocoDataset.model_validate_json(src_json_data)
         assert reinstated_dataset == dataset
 
-def test_labels_to_dataset_append_dataset(tmp_path: pathlib.Path, test_raster: pathlib.Path, overlapping_labels: gpd.GeoDataFrame) -> None:
+
+def test_labels_to_dataset_append_dataset(
+    tmp_path: pathlib.Path,
+    test_raster: pathlib.Path,
+    overlapping_labels: gpd.GeoDataFrame,
+) -> None:
     with rasterio.open(test_raster) as raster_source:
         # Creating empty CocoDataset as input for labels_to_dataset
-        info = Info(version = "0.0.1", date_created=datetime.now())
+        info = Info(version="0.0.1", date_created=datetime.now())
         dataset = CocoDataset(info=info)
         dataset = labels_to_dataset(
-            dataset = dataset,
-            images_dir = tmp_path,
-            src = raster_source,
-            labels = overlapping_labels,
-            window_bounds = [(256, 256)]
-            )
-        
+            dataset=dataset,
+            images_dir=tmp_path,
+            src=raster_source,
+            labels=overlapping_labels,
+            window_bounds=[(256, 256)],
+        )
+
         # Checking if output has correct classes
         unique_ann_ids = np.unique([ann.category_id for ann in dataset.annotations])
-        assert np.all(np.isin(unique_ann_ids, overlapping_labels['category_id'].unique()))
+        assert np.all(
+            np.isin(unique_ann_ids, overlapping_labels["category_id"].unique())
+        )
 
         # Rerunning with existing CocoDataset to verify append
         previous_dataset = dataset.copy(deep=True)
-        previous_image_id = dataset.next_image_id - 1 
+        previous_image_id = dataset.next_image_id - 1
         previous_annotation_id = dataset.next_annotation_id - 1
-        
+
         dataset = labels_to_dataset(
-            dataset = dataset,
-            images_dir = tmp_path,
-            src = raster_source,
-            labels = overlapping_labels,
-            window_bounds = [(256, 256)]
-            )
-        
+            dataset=dataset,
+            images_dir=tmp_path,
+            src=raster_source,
+            labels=overlapping_labels,
+            window_bounds=[(256, 256)],
+        )
+
         # Checking whether new data was added without touching existing data
         current_annotations = dataset.annotations[:previous_annotation_id]
         current_images = dataset.images[:previous_image_id]
@@ -76,6 +89,13 @@ def test_labels_to_dataset_append_dataset(tmp_path: pathlib.Path, test_raster: p
         assert dataset.next_image_id != previous_image_id
         assert dataset.next_annotation_id != previous_annotation_id
         assert len(current_annotations) == len(previous_dataset.annotations)
-        assert len(current_images) == len(previous_dataset.images)    
-        assert np.all([current_images[i] == ann for i, ann in enumerate(previous_dataset.images)])
-        assert np.all([current_annotations[i] == image for i, image in enumerate(previous_dataset.annotations)])
+        assert len(current_images) == len(previous_dataset.images)
+        assert np.all(
+            [current_images[i] == ann for i, ann in enumerate(previous_dataset.images)]
+        )
+        assert np.all(
+            [
+                current_annotations[i] == image
+                for i, image in enumerate(previous_dataset.annotations)
+            ]
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,20 +3,35 @@ import pathlib
 import rasterio
 import numpy as np
 from rasterio.windows import Window
-from geococo.utils import window_intersect, generate_window_offsets, window_factory, reshape_image, generate_window_polygon, estimate_average_bounds, estimate_schema, mask_label
+from geococo.utils import (
+    window_intersect,
+    generate_window_offsets,
+    window_factory,
+    reshape_image,
+    generate_window_polygon,
+    estimate_average_bounds,
+    estimate_schema,
+    mask_label,
+)
 from geococo.window_schema import WindowSchema
 import geopandas as gpd
 from typing import Tuple
 
-def test_mask_label_overlapping(overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+
+def test_mask_label_overlapping(
+    overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path
+) -> None:
     with rasterio.open(test_raster) as raster_source:
         for _, row in overlapping_labels.iterrows():
             masked_label = mask_label(input_raster=raster_source, label=row.geometry)
             assert masked_label.ndim == 2
             assert masked_label.dtype == bool
             assert masked_label.sum() >= row.geometry.area
-        
-def test_mask_label_nonoverlapping(nonoverlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+
+
+def test_mask_label_nonoverlapping(
+    nonoverlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path
+) -> None:
     with rasterio.open(test_raster) as raster_source:
         for _, row in nonoverlapping_labels.iterrows():
             masked_label = mask_label(input_raster=raster_source, label=row.geometry)
@@ -24,143 +39,244 @@ def test_mask_label_nonoverlapping(nonoverlapping_labels: gpd.GeoDataFrame, test
             assert masked_label.dtype == bool
             assert masked_label.sum() == 0
 
-def test_mask_label_closed(overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+
+def test_mask_label_closed(
+    overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path
+) -> None:
     raster_source = rasterio.open(test_raster)
     raster_source.close()
     with pytest.raises(ValueError):
-        mask_label(input_raster=raster_source, label=overlapping_labels.geometry.values[0])
-    
-def test_window_intersect(overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+        mask_label(
+            input_raster=raster_source, label=overlapping_labels.geometry.values[0]
+        )
+
+
+def test_window_intersect(
+    overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path
+) -> None:
     with rasterio.open(test_raster) as raster_source:
-        # outer polygons have diameter of 2 so resulting window is 82x82 and offset is 9 (10-2/2)
-        window = window_intersect(input_raster=raster_source, input_vector=overlapping_labels)
+        # outer polygons have diameter of 2 so resulting window 
+        # is 82x82 and offset is 9 (10-2/2)
+        window = window_intersect(
+            input_raster=raster_source, input_vector=overlapping_labels
+        )
         assert window.col_off == 9
         assert window.row_off == 9
         assert window.width == 82
         assert window.height == 82
 
-def test_window_intersect_invalid(nonoverlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+
+def test_window_intersect_invalid(
+    nonoverlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path
+) -> None:
     with rasterio.open(test_raster) as raster_source:
         with pytest.raises(ValueError):
-            window_intersect(input_raster=raster_source, input_vector=nonoverlapping_labels)
+            window_intersect(
+                input_raster=raster_source, input_vector=nonoverlapping_labels
+            )
 
-@pytest.mark.parametrize("padding_value,original_shape,requested_shape", [(0, (3, 256, 256), (3, 512, 512)), (-10000,(3, 256, 256), (4, 512, 512))])
-def test_reshape_image_pad(padding_value: int, original_shape: Tuple[int, int, int] , requested_shape: Tuple[int, int, int]) -> None:
+
+@pytest.mark.parametrize(
+    "padding_value,original_shape,requested_shape",
+    [(0, (3, 256, 256), (3, 512, 512)), (-10000, (3, 256, 256), (4, 512, 512))],
+)
+def test_reshape_image_pad(
+    padding_value: int,
+    original_shape: Tuple[int, int, int],
+    requested_shape: Tuple[int, int, int],
+) -> None:
     img_array = np.random.randint(0, 255, original_shape)
-    reshaped_image = reshape_image(img_array=img_array, shape=requested_shape, padding_value=padding_value)
+    reshaped_image = reshape_image(
+        img_array=img_array, shape=requested_shape, padding_value=padding_value
+    )
     assert reshaped_image.shape == requested_shape
-    assert np.array_equal(reshaped_image[:original_shape[0], :original_shape[1], :original_shape[2]], img_array)
-    assert np.all(reshaped_image[:, original_shape[1]:, original_shape[2]:] == padding_value)
+    assert np.array_equal(
+        reshaped_image[: original_shape[0], : original_shape[1], : original_shape[2]],
+        img_array,
+    )
+    assert np.all(
+        reshaped_image[:, original_shape[1] :, original_shape[2] :] == padding_value
+    )
 
-@pytest.mark.parametrize("original_shape,requested_shape", [((3, 256, 256), (3, 200, 210)), ((3, 256, 256), (1, 100, 120))])
-def test_reshape_image_slicing(original_shape: Tuple[int, int, int], requested_shape: Tuple[int, int, int]) -> None:
+
+@pytest.mark.parametrize(
+    "original_shape,requested_shape",
+    [((3, 256, 256), (3, 200, 210)), ((3, 256, 256), (1, 100, 120))],
+)
+def test_reshape_image_slicing(
+    original_shape: Tuple[int, int, int], requested_shape: Tuple[int, int, int]
+) -> None:
     img_array = np.random.randint(0, 255, original_shape)
     reshaped_image = reshape_image(img_array=img_array, shape=requested_shape)
     assert reshaped_image.shape == requested_shape
-    assert np.array_equal(img_array[:requested_shape[0], :requested_shape[1], :requested_shape[2]], reshaped_image)
+    assert np.array_equal(
+        img_array[: requested_shape[0], : requested_shape[1], : requested_shape[2]],
+        reshaped_image,
+    )
+
 
 @pytest.mark.parametrize("span, offset", [(100, 0), (5, -100), (100, 100), (256, 800)])
-def test_generate_window_polygon(span: int, offset: int, test_raster: pathlib.Path) -> None:    
-    with rasterio.open(test_raster) as raster_source: # only provides transform
-        window_geom = generate_window_polygon(raster_source, Window(offset, offset, span, span))
+def test_generate_window_polygon(
+    span: int, offset: int, test_raster: pathlib.Path
+) -> None:
+    with rasterio.open(test_raster) as raster_source:  # only provides transform
+        window_geom = generate_window_polygon(
+            raster_source, Window(offset, offset, span, span)
+        )
         # window_geom.bounds (minx, miny, maxx, maxy)
         assert window_geom.bounds == (offset, -span - offset, span + offset, -offset)
-        
+
+
 def test_generate_window_polygon_negative(test_raster: pathlib.Path) -> None:
-    with rasterio.open(test_raster) as raster_source: # only provides transform
+    with rasterio.open(test_raster) as raster_source:  # only provides transform
         with pytest.raises(ValueError):
             generate_window_polygon(raster_source, Window(0, 0, -256, -256))
-    
-@pytest.mark.parametrize("quantile, expected_bounds", [(0.1, 2), (0.5, 4), (0.6, 4.8), (0.8, 6.4)])
-def test_estimate_average_bounds(quantile: float, expected_bounds: float, overlapping_labels: gpd.GeoDataFrame) -> None:
-    average_width, average_height = estimate_average_bounds(gdf=overlapping_labels, quantile=quantile)
+
+
+@pytest.mark.parametrize(
+    "quantile, expected_bounds", [(0.1, 2), (0.5, 4), (0.6, 4.8), (0.8, 6.4)]
+)
+def test_estimate_average_bounds(
+    quantile: float, expected_bounds: float, overlapping_labels: gpd.GeoDataFrame
+) -> None:
+    average_width, average_height = estimate_average_bounds(
+        gdf=overlapping_labels, quantile=quantile
+    )
     assert average_height == expected_bounds
     assert average_width == expected_bounds
 
-@pytest.mark.parametrize("quantile, bounds",  [(0.8, (100, 100)), (0.8, (15, 15)), (0.2, (15, 15))])
-def test_estimate_schema(quantile: float, bounds: Tuple[int, int], overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+
+@pytest.mark.parametrize(
+    "quantile, bounds", [(0.8, (100, 100)), (0.8, (15, 15)), (0.2, (15, 15))]
+)
+def test_estimate_schema(
+    quantile: float,
+    bounds: Tuple[int, int],
+    overlapping_labels: gpd.GeoDataFrame,
+    test_raster: pathlib.Path,
+) -> None:
     with rasterio.open(test_raster) as raster_source:
         schema = estimate_schema(
             gdf=overlapping_labels,
             src=raster_source,
             window_bounds=[bounds],
-            quantile=quantile
-            )
+            quantile=quantile,
+        )
         # verifying that bounds are respected (ultimately determines output image size)
         assert schema.width_window == bounds[0]
         assert schema.height_window == bounds[1]
 
-        label_span, _ = estimate_average_bounds(gdf=overlapping_labels, quantile=quantile)
+        label_span, _ = estimate_average_bounds(
+            gdf=overlapping_labels, quantile=quantile
+        )
         # verifying that the label sample fits in the window overlap
         assert schema.width_overlap >= label_span
         assert schema.height_overlap >= label_span
 
-@pytest.mark.parametrize("quantile, bounds",  [(0.8, (14, 14)), (0.5, (8, 8)), (0.2, (4, 4))])
-def test_estimate_schema_invalid(quantile: float, bounds: Tuple[int, int], overlapping_labels: gpd.GeoDataFrame, test_raster: pathlib.Path) -> None:
+
+@pytest.mark.parametrize(
+    "quantile, bounds", [(0.8, (14, 14)), (0.5, (8, 8)), (0.2, (4, 4))]
+)
+def test_estimate_schema_invalid(
+    quantile: float,
+    bounds: Tuple[int, int],
+    overlapping_labels: gpd.GeoDataFrame,
+    test_raster: pathlib.Path,
+) -> None:
     with rasterio.open(test_raster) as raster_source:
         with pytest.raises(ValueError):
             estimate_schema(
                 gdf=overlapping_labels,
                 src=raster_source,
                 window_bounds=[bounds],
-                quantile=quantile
-                )
-    
-@pytest.mark.parametrize("col_off, row_off, width, height", [(0, 0, 256, 256), (0, 0, 256, 120), (100, 100, 256, 256), (-100, -100, 256, 256), (0, 0, 50, 50)])
-def test_generate_window_offsets_window(col_off: int, row_off: int, width: int, height:int ) -> None:
+                quantile=quantile,
+            )
+
+
+@pytest.mark.parametrize(
+    "col_off, row_off, width, height",
+    [
+        (0, 0, 256, 256),
+        (0, 0, 256, 120),
+        (100, 100, 256, 256),
+        (-100, -100, 256, 256),
+        (0, 0, 50, 50),
+    ],
+)
+def test_generate_window_offsets_window(
+    col_off: int, row_off: int, width: int, height: int
+) -> None:
     schema = WindowSchema(
-        width_window=100,
-        width_overlap=10,
-        height_window=100,
-        height_overlap=10
-        ) # type: ignore
-    
+        width_window=100, width_overlap=10, height_window=100, height_overlap=10
+    )  # type: ignore
+
     window = Window(col_off, row_off, width, height)
     offsets = generate_window_offsets(window=window, schema=schema)
     assert np.all(offsets >= 0)
     assert np.all(offsets[:, 0] <= width + schema.width_window)
-    assert np.all(offsets[:, 1] <= height + schema.height_window)   
+    assert np.all(offsets[:, 1] <= height + schema.height_window)
 
 
-@pytest.mark.parametrize("width_window, width_overlap, height_window, height_overlap", [(100, 0, 100, 0), (100, 49, 100, 49), (300, 0, 300, 0)])
-def test_generate_window_offsets_schema(width_window: int, width_overlap: int, height_window: int, height_overlap: int) -> None:
+@pytest.mark.parametrize(
+    "width_window, width_overlap, height_window, height_overlap",
+    [(100, 0, 100, 0), (100, 49, 100, 49), (300, 0, 300, 0)],
+)
+def test_generate_window_offsets_schema(
+    width_window: int, width_overlap: int, height_window: int, height_overlap: int
+) -> None:
     window = Window(0, 0, 256, 256)
     schema = WindowSchema(
         width_window=width_window,
         width_overlap=width_overlap,
         height_window=height_window,
-        height_overlap=height_overlap
-    ) # type: ignore
+        height_overlap=height_overlap,
+    )  # type: ignore
 
     offsets = generate_window_offsets(window=window, schema=schema)
     assert np.all(offsets >= 0)
     assert np.all(offsets[:, 0] <= window.width + schema.width_window)
-    assert np.all(offsets[:, 1] <= window.height + schema.height_window)   
+    assert np.all(offsets[:, 1] <= window.height + schema.height_window)
+
 
 def test_window_factory_not_boundless() -> None:
-    boundless = False    
+    boundless = False
     schema = WindowSchema(
-        width_window=100,
-        width_overlap=10,
-        height_window=100,
-        height_overlap=10
-        ) # type: ignore
+        width_window=100, width_overlap=10, height_window=100, height_overlap=10
+    )  # type: ignore
     window = Window(0, 0, 1000, 1000)
 
-    window_extents = np.array([[child_window.col_off + child_window.width, child_window.row_off + child_window.height] for child_window in window_factory(parent_window=window, schema=schema, boundless=boundless)])
+    window_extents = np.array(
+        [
+            [
+                child_window.col_off + child_window.width,
+                child_window.row_off + child_window.height,
+            ]
+            for child_window in window_factory(
+                parent_window=window, schema=schema, boundless=boundless
+            )
+        ]
+    )
     assert np.all(window_extents[:, 0] <= window.width)
     assert np.all(window_extents[:, 1] <= window.height)
-    
+
+
 def test_window_factory_boundless() -> None:
     boundless = True
     schema = WindowSchema(
-        width_window=100,
-        width_overlap=10,
-        height_window=100,
-        height_overlap=10
-        ) # type: ignore
+        width_window=100, width_overlap=10, height_window=100, height_overlap=10
+    )  # type: ignore
     window = Window(0, 0, 1000, 1000)
 
-    window_extents = np.array([[child_window.col_off + child_window.width, child_window.row_off + child_window.height] for child_window in window_factory(parent_window=window, schema=schema, boundless=boundless)])
+    window_extents = np.array(
+        [
+            [
+                child_window.col_off + child_window.width,
+                child_window.row_off + child_window.height,
+            ]
+            for child_window in window_factory(
+                parent_window=window, schema=schema, boundless=boundless
+            )
+        ]
+    )
     assert np.any(window_extents[:, 0] >= window.width)
     assert np.any(window_extents[:, 1] >= window.height)

--- a/tests/test_window_schema.py
+++ b/tests/test_window_schema.py
@@ -17,6 +17,7 @@ def test_schema_valid():
     assert schema.width_step == width_window - width_overlap * 2
     assert schema.height_step == height_window - height_overlap * 2
 
+
 @pytest.mark.parametrize("test_input", [(0, 20), (100, -20), (100, 50)])
 def test_schema_invalid(test_input):
     window, overlap = test_input
@@ -30,6 +31,7 @@ def test_schema_invalid(test_input):
             height_window=height_window,
             height_overlap=height_overlap,
         )
+
 
 @pytest.mark.parametrize("test_input", [(100, 20.0), (100.0, 20)])
 def test_schema_float(test_input):
@@ -45,13 +47,15 @@ def test_schema_float(test_input):
             height_overlap=height_overlap,
         )
 
+
 @pytest.mark.parametrize("test_input", [("100", 20), (100, "20")])
 def test_schema_str(test_input):
     window, overlap = test_input
     width_window = height_window = window
     width_overlap = height_overlap = overlap
-    
-    # TypeError is raised because 'steps' are calculated before pydantic's field validation
+
+    # TypeError is raised because 'steps' are calculated 
+    # before pydantic's field validation
     with pytest.raises(TypeError):
         WindowSchema(
             width_window=width_window,


### PR DESCRIPTION
Feature branch that adds automates SemVer changes to a COCO dataset based on input data (meaning users are no longer prompted to provide versions themselves). This is possible because we now keep track of the raster sources used to make the image subsets that contained annotations, technically making it a COCO superset (i.e. GeoCOCO datasets have all COCO-required keys plus others). It is still compatible with any COCO-accepting data applications though.

New COCO datasets are tagged as '1.0.0`, indicating that all initial annotations are made from the same raster source and stored in the same output directory. 
- PATCH: If this same dataset is used again to store (updated) annotations from the same raster source in the same output directory, we treat it as a patch and bump the SemVer version by 0.0.1.
- MINOR: If this same dataset is used again to store annotations from a new raster source in the same output directory, we treat it as a minor release and bump the SemVer version by 0.1.0.
- MAJOR: Lastly, if this same dataset is used again to store annotations from any raster source (new or existing) in a new output directory, we treat it as a major release and bump the SemVer version by 1.0.0. That is because it technically introduces breaking changes as you now have n+1 output directories to keep track of.

It is also the first branch released under the Github Actions based CI meaning that all (existing and new) code is tested and checked for formatting and sufficient test coverage (using mypy, pytest, pytest-cov, ruff).