### PR TITLE
Added cli options for (super)category names and ids

### DIFF
--- a/geococo/coco_models.py
+++ b/geococo/coco_models.py
@@ -117,7 +117,7 @@ class CocoDataset(BaseModel):
         # ensuring equal size for category names and ids (if given)
         else:
             assert category_names.shape == original_shape  # type: ignore[union-attr]
-            category_names = category_names[indices][~member_mask]  # type: ignore[index]
+            category_names = category_names[indices][~member_mask] # type: ignore[index]
             category_ids = new_members
 
         # iteratively instancing and appending Category from set ids, names and supers

--- a/geococo/coco_models.py
+++ b/geococo/coco_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import numpy as np
 import pathlib
 import pandas as pd
+from pandas import Series
 from datetime import datetime
 from typing import List, Optional, Dict, Any
 from typing_extensions import TypedDict
@@ -50,9 +51,9 @@ class CocoDataset(BaseModel):
 
     def add_categories(
         self,
-        category_ids: Optional[np.ndarray],
-        category_names: Optional[np.ndarray],
-        supercategory_names: Optional[np.ndarray],
+        category_ids: Optional[Series],
+        category_names: Optional[Series],
+        super_names: Optional[Series],
     ) -> None:
         # initializing values
         super_default = "1"
@@ -65,13 +66,15 @@ class CocoDataset(BaseModel):
         )
 
         # checking if names can be assigned to uid_array (used to check duplicates)
-        if isinstance(category_names, np.ndarray):
+        if category_names is not None:
+            category_names: np.ndarray = category_names.to_numpy()
             uid_array = category_names
             uid_attribute = "name"
             names_present = True
 
         # checking if ids can be assigned to uid_array (used to check duplicates)
-        if isinstance(category_ids, np.ndarray):
+        if category_ids is not None:
+            category_ids: np.ndarray = category_ids.to_numpy()
             uid_array = category_ids  # overrides existing array because ids are leading
             uid_attribute = "id"
             ids_present = True
@@ -89,11 +92,15 @@ class CocoDataset(BaseModel):
             return
 
         # creating default supercategory_names if not given
-        if not isinstance(supercategory_names, np.ndarray):
-            supercategory_names = np.full(shape=new_shape, fill_value=super_default)
+        if super_names is None:
+            super_names = np.full(
+                shape=new_shape,
+                fill_value=super_default
+                ) # type: ignore[assignment]
         else:
-            assert supercategory_names.shape == original_shape
-            supercategory_names = supercategory_names[indices][~member_mask]
+            super_names: np.ndarray = super_names.to_numpy()
+            assert super_names.shape == original_shape
+            super_names = super_names[indices][~member_mask]
 
         # creating default category_names if not given (str version of ids)
         if ids_present and not names_present:
@@ -105,16 +112,17 @@ class CocoDataset(BaseModel):
             max_id = category_pd.loc[pandas_mask, "id"].max()
             start = np.nansum([max_id, 1])
             end = start + new_members.size
-            category_ids = np.arange(start, end)
+            category_ids = np.arange(start, end) # type: ignore[assignment]
             category_names = new_members
         # ensuring equal size for category names and ids (if given)
         else:
-            assert category_names.shape == original_shape # type: ignore
-            category_names = category_names[indices][~member_mask] # type: ignore
+            assert category_names.shape == original_shape  # type: ignore[union-attr]
+            category_names = category_names[indices][~member_mask]  # type: ignore[index]
             category_ids = new_members
 
         # iteratively instancing and appending Category from set ids, names and supers
-        for cid, name, super in zip(category_ids, category_names, supercategory_names):
+        cip = zip(category_ids, category_names, super_names)
+        for cid, name, super in cip:
             category = Category(id=cid, name=name, supercategory=super)
             self.categories.append(category)
 

--- a/geococo/coco_processing.py
+++ b/geococo/coco_processing.py
@@ -5,7 +5,6 @@ from typing import List, Tuple
 import geopandas as gpd
 import numpy as np
 import rasterio
-from pandas import Series
 from typing import Optional
 from rasterio.io import DatasetReader
 from rasterio.mask import mask as riomask
@@ -66,23 +65,11 @@ def labels_to_dataset(
         supercategory_col=supercategory_col,
     )
 
-    # dumping series to array (if present)
-    category_ids = labels.get(category_id_col)
-    category_ids = category_ids.values if isinstance(category_ids, Series) else None
-    category_names = labels.get(category_name_col)
-    category_names = (
-        category_names.values if isinstance(category_names, Series) else None
-    )
-    supercategory_names = labels.get(supercategory_col)
-    supercategory_names = (
-        supercategory_names.values if isinstance(supercategory_names, Series) else None
-    )
-
-    # adding new Category instances (if any)
+    # adding new Category instances from labels (if any)
     dataset.add_categories(
-        category_ids=category_ids,
-        category_names=category_names,
-        supercategory_names=supercategory_names,
+        category_ids=labels.get(category_id_col),
+        category_names=labels.get(category_name_col),
+        super_names=labels.get(supercategory_col),
     )
 
     # updating labels with validated COCO keys (i.e. 'name', 'id', 'supercategory')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geococo"
-version = "0.4.0"
+version = "0.4.1"
 description = "Converts GIS annotations to Microsoft's Common Objects In Context (COCO) dataset format"
 authors = ["Jasper <j.siebring92@gmail.com>"]
 readme = "README.md"
@@ -42,7 +42,12 @@ module = [
     "geopandas",
     "shapely.*"
 ]
+
+[tool.mypy]
 ignore_missing_imports = true
+allow_redefinition = true
+strict_optional = false
+disable_error_code = 'no-redef'
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_coco_models.py
+++ b/tests/test_coco_models.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 import pytest
 import os
 import numpy as np
+import pandas as pd
 import pathlib
 from datetime import datetime
+from pydantic import ValidationError
 from geococo.coco_models import (
     CocoDataset,
     Info,
@@ -171,14 +173,14 @@ def test_add_categories_by_ids():
     assert dataset.categories == []
 
     # adding three unique classes
-    category_ids = np.array([1, 2, 2, 5, 5])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
     category_names = None
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_ids).size
@@ -197,13 +199,13 @@ def test_add_categories_by_names():
 
     # adding three unique classes
     category_ids = None
-    category_names = np.array([1, 2, 2, 5, 5]).astype(str)
+    category_names = pd.Series([1, 2, 2, 5, 5]).astype(str)
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_names).size
@@ -221,14 +223,14 @@ def test_add_categories_by_names_and_ids():
     assert dataset.categories == []
 
     # adding three unique classes
-    category_ids = np.array([1, 2, 2, 5, 5])
-    category_names = np.array(["One", "Two", "Two", "Five", "Five"])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
+    category_names = pd.Series(["One", "Two", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_names).size
@@ -251,14 +253,14 @@ def test_add_categories_with_supers():
     assert dataset.categories == []
 
     # adding three unique classes
-    category_ids = np.array([1, 2, 2, 5, 5])
-    category_names = np.array(["One", "Two", "Two", "Five", "Five"])
-    supercategory_names = np.array(["A", "A", "A", "B", "B"])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
+    category_names = pd.Series(["One", "Two", "Two", "Five", "Five"])
+    supercategory_names = pd.Series(["A", "A", "A", "B", "B"])
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_names).size
@@ -282,14 +284,14 @@ def test_add_categories_by_names_and_ids_append_specific():
     assert dataset.categories == []
 
     # adding three unique classes
-    category_ids = np.array([1, 2, 2, 5, 5])
-    category_names = np.array(["One", "Two", "Two", "Five", "Five"])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
+    category_names = pd.Series(["One", "Two", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_names).size
@@ -310,14 +312,14 @@ def test_add_categories_by_names_and_ids_append_specific():
     n_categories = len(dataset.categories)
 
     # adding one new class and 4 duplicates
-    category_ids = np.array([1, 8, 2, 5, 5])
-    category_names = np.array(["One", "Eight", "Two", "Five", "Five"])
+    category_ids = pd.Series([1, 8, 2, 5, 5])
+    category_names = pd.Series(["One", "Eight", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == n_categories + 1
@@ -330,14 +332,14 @@ def test_add_categories_by_names_and_ids_append_auto():
     assert dataset.categories == []
 
     # adding three unique classes
-    category_ids = np.array([1, 2, 2, 5, 5])
-    category_names = np.array(["One", "Two", "Two", "Five", "Five"])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
+    category_names = pd.Series(["One", "Two", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_names).size
@@ -359,13 +361,13 @@ def test_add_categories_by_names_and_ids_append_auto():
 
     # adding one new class and 4 duplicates (only by name, not by id)
     category_ids = None
-    category_names = np.array(["One", "Eight", "Two", "Five", "Five"])
+    category_names = pd.Series(["One", "Eight", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == n_categories + 1
@@ -378,14 +380,14 @@ def test_add_categories_by_names_and_ids_duplicates():
     assert dataset.categories == []
 
     # adding three unique classes
-    category_ids = np.array([1, 2, 2, 5, 5])
-    category_names = np.array(["One", "Two", "Two", "Five", "Five"])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
+    category_names = pd.Series(["One", "Two", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == np.unique(category_names).size
@@ -407,14 +409,14 @@ def test_add_categories_by_names_and_ids_duplicates():
     cats = [cat for cat in dataset.categories]
 
     # adding duplicate ids and names
-    category_ids = np.array([1, 2, 2, 5, 5])
-    category_names = np.array(["One", "Two", "Two", "Five", "Five"])
+    category_ids = pd.Series([1, 2, 2, 5, 5])
+    category_names = pd.Series(["One", "Two", "Two", "Five", "Five"])
     supercategory_names = None
 
     dataset.add_categories(
         category_ids=category_ids,
         category_names=category_names,
-        supercategory_names=supercategory_names,
+        super_names=supercategory_names,
     )
 
     assert len(dataset.categories) == n_categories
@@ -433,20 +435,20 @@ def test_add_categories_faulty():
         dataset.add_categories(
             category_ids=category_ids,
             category_names=category_names,
-            supercategory_names=supercategory_names,
+            super_names=supercategory_names,
         )
 
     dataset = CocoDataset(info=Info())
     assert dataset.categories == []
 
     # Ids of different len than names
-    category_ids = np.array([1, 2, 3])
-    category_names = np.array(["1", "2"])
+    category_ids = pd.Series([1, 2, 3])
+    category_names = pd.Series(["1", "2"])
     with pytest.raises(AssertionError):
         dataset.add_categories(
             category_ids=category_ids,
             category_names=category_names,
-            supercategory_names=supercategory_names,
+            super_names=supercategory_names,
         )
 
     dataset = CocoDataset(info=Info())
@@ -459,16 +461,15 @@ def test_add_categories_faulty():
         dataset.add_categories(
             category_ids=category_ids,
             category_names=category_names,
-            supercategory_names=supercategory_names,
+            super_names=supercategory_names,
         )
 
     dataset = CocoDataset(info=Info())
     assert dataset.categories == []
 
     # Nullable arrays (would also get caught by validate_labels
-    category_ids = np.array([1, 2, 3, None, 5])
-
-    with pytest.raises(TypeError):
+    category_ids = pd.Series([1, 2, 3, None, 5])
+    with pytest.raises(ValidationError):
         dataset.add_categories(
-            category_ids=category_ids, category_names=None, supercategory_names=None
+            category_ids=category_ids, category_names=None, super_names=None
         )


### PR DESCRIPTION
Small PR, basically only adds options to specify columns with (super)category names and ids values to cli (underlying functionality was introduced in 0.4.0). Also changed type hints for add_categories' kwargs to Series.